### PR TITLE
Added the ability to search for patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,29 @@
   "qna": "https://r2c.dev/slack",
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "semgrep-explorer",
+          "title": "Semgrep Explorer",
+          "icon": "semgrep-icon.png"
+        }
+      ]
+    },
+    "views": {
+      "semgrep-explorer": [
+        {
+          "id": "semgrepTreeView",
+          "name": "Results"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "semgrepTreeView",
+        "contents": "[Search Pattern](command:semgrep.searchPattern)"
+      }
+    ],
     "commands": [
       {
         "command": "semgrep.suggestSelectionPatterns",
@@ -38,6 +61,15 @@
       {
         "command": "semgrep.suggestLinePatterns",
         "title": "Suggest Semgrep Patterns for Line"
+      },
+      {
+        "command": "semgrep.searchPattern",
+        "title": "Search Semgrep Pattern"
+      },
+      {
+        "command": "semgrep.deleteEntry",
+        "title": "Delete Finding in Semgrep",
+        "icon": "$(close)"
       }
     ],
     "configuration": {
@@ -64,6 +96,27 @@
           "description": "The semgrep --config value to scan with."
         }
       }
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "semgrep.searchPattern",
+          "when": "view == semgrepTreeView"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "semgrep.deleteEntry",
+          "when": "view == semgrepTreeView && viewItem == finding",
+          "group": "inline"
+        }
+      ],
+      "commandPalette": [
+        {
+            "command": "semgrep.deleteEntry",
+            "when": "false"
+        }
+    ]
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,12 @@
 import * as vscode from "vscode";
 import activateDiagnostics from "./diagnostics";
 import activateSuggestions from "./suggestions";
+import activateSearch from "./search";
 
 export const activate = async (context: vscode.ExtensionContext) => {
   activateSuggestions(context);
   activateDiagnostics(context);
+  activateSearch(context);
 };
 
 export const deactivate = () => {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,171 @@
+
+import * as vscode from "vscode";
+import { searchPatternWorkspace } from "./cli";
+
+
+const activateSearch = async (context: vscode.ExtensionContext) => {
+    const semgrepSearchProvider = new SemgrepSearchProvider();
+    const customView = vscode.window.createTreeView("semgrepTreeView", {treeDataProvider:semgrepSearchProvider});
+    
+    const subs = context.subscriptions;
+    subs.push(
+      vscode.commands.registerCommand(
+        "semgrep.searchPattern",
+        async (context: vscode.ExtensionContext) => await semgrepSearchProvider.search()
+      )
+    );
+    
+    subs.push(
+      vscode.commands.registerCommand(
+        "semgrep.goToFile",
+        async (filePath: string, lineNumber: number) => await semgrepSearchProvider.goToFile(filePath, lineNumber)
+      )
+    );
+
+    subs.push(
+      vscode.commands.registerCommand(
+        "semgrep.deleteEntry",
+        async (element: Finding | SearchResult) => await semgrepSearchProvider.deleteElement(element)
+      )
+    );
+}
+
+export class SemgrepSearchProvider implements vscode.TreeDataProvider<SearchResult | Finding> {
+
+  private _onDidChangeTreeData: vscode.EventEmitter<
+  SearchResult | null
+> = new vscode.EventEmitter<SearchResult | null>();
+readonly onDidChangeTreeData: vscode.Event<SearchResult | null> = this
+  ._onDidChangeTreeData.event;
+
+
+  private results: SearchResult[] = [];
+
+  getTreeItem(element: SearchResult): vscode.TreeItem {
+    return element;
+  }
+
+  getParent(element: SearchResult | Finding): SearchResult | Finding | undefined {
+
+    /*I thought about this for a long time.
+      I know this is not the most effective way of doing this
+      but it is the easiest. Computers are fast tell this becomes
+      a problem i'm just going to leave it like this
+    */
+    this.results.forEach(e => {
+      e.fingings.forEach(f => {
+        if(f === element){
+          return e;
+        }
+      });
+    });
+
+
+    return undefined
+  }
+
+  deleteElement(element: SearchResult | Finding) {
+
+    if (element instanceof SearchResult) {
+      this.results = this.results.filter((e) => {
+        return e !== element
+      })
+    } else {
+      this.results.forEach((e) => {
+        e.fingings = e.fingings.filter((f) => {
+          if (f !== element) { return true }
+
+          //We are going to remove this element so we need to subtract one
+          e.description = String(e.fingings.length-1)
+          
+        })
+      })
+    }
+
+    this._onDidChangeTreeData.fire();
+  }
+
+  getChildren(element?: SearchResult): Thenable<SearchResult[]> | Thenable<Finding[]> {
+
+    if (element == undefined) {
+      return Promise.resolve(this.results)
+    }
+
+    return Promise.resolve(element.fingings)
+
+    
+  }
+
+  goToFile = async (filePath: string, lineNumber: number) => {
+    const  openPath = vscode.Uri.parse( "file://" + filePath);
+    const document = await vscode.workspace.openTextDocument(openPath)
+
+    const editor = await vscode.window.showTextDocument(document)
+
+    editor.revealRange(new vscode.Range(lineNumber,0,lineNumber,0))//TODO: we should most likely add the end as well since it provided
+    editor.selection = new vscode.Selection(lineNumber,0,lineNumber,0)
+  }
+
+  search = async () => {
+    const inputResult = await vscode.window.showInputBox({
+		value: '',
+		placeHolder: 'Enter Search Pattern',
+    });
+    
+    //User has canceled the request
+    if (inputResult == undefined) {
+        return
+    }
+
+    const quickPickResult = await vscode.window.showQuickPick(['py', 'js', 'rb', 'go'], {
+      placeHolder: 'py, js, rb or go',});
+
+
+    //User has canceled the request
+    if (quickPickResult == undefined) {
+      return
+    }
+
+
+    const path = vscode.workspace.workspaceFolders;
+
+    if (path == undefined) {
+      return
+    }
+ 
+    
+    const output = await searchPatternWorkspace(path[0].uri.fsPath, inputResult, quickPickResult)
+
+    this.results = output;//TODO: should a pass this into the fire function instead of using the global scope?
+    this._onDidChangeTreeData.fire();
+}
+
+
+
+
+}
+
+export class SearchResult extends vscode.TreeItem {
+
+
+  constructor(public readonly label: string, 
+    public fingings: Finding[],
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly resourceUri: vscode.Uri
+    ) {
+      super(label, collapsibleState)
+      this.iconPath = vscode.ThemeIcon.File
+    }
+}
+
+export class Finding extends vscode.TreeItem {
+  constructor(public readonly label: string, 
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly command?: vscode.Command
+    ) {
+    super(label, collapsibleState)
+    this.contextValue = "finding"
+  }
+}
+
+export default activateSearch;

--- a/src/search.ts
+++ b/src/search.ts
@@ -117,8 +117,19 @@ readonly onDidChangeTreeData: vscode.Event<SearchResult | null> = this
         return
     }
 
-    const quickPickResult = await vscode.window.showQuickPick(['py', 'js', 'rb', 'go'], {
-      placeHolder: 'py, js, rb or go',});
+    const quickPickResult = await vscode.window.showQuickPick(["c",
+    "go",
+    "java",
+    "javascript",
+    "javascriptreact",
+    "json",
+    "ocaml",
+    "php",
+    "python",
+    "ruby",
+    "typescript",
+    "typescriptreact"], {
+    placeHolder: 'select target language',});
 
 
     //User has canceled the request


### PR DESCRIPTION
Recently, I decided to learn a little about typescript and VScode extension and I noticed that this extension was missing some of the features I needed. One of the key features was the ability to search for a pattern and get the results. That is what is included in this pull request.

To perform this I created a custom panel in VScode with the treeview provider. When searching, using the command `Search Semgrep Pattern` (No hotkey for now as I have no clue how to pick hotkeys without making conflicts), you will be asked to enter your pattern and the language. The treeview will then be populated with the results. 

There are still some other features on my todo list but I wanted to get feedback, and maybe get it merged, on this before moving forward. 
