### PR TITLE
Config: comma-separated list of rule sets in addition to single paths

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,9 +70,11 @@ export const checkFile = async (
   path: string,
   rules: string
 ): Promise<vscode.Diagnostic[]> => {
+  const args = ['--json'];
+  rules.split(',').forEach(element => args.push('--config', element));
+  args.push(path);
   const { stdout, stderr } = await execFileAsync(
-    "semgrep",
-    ["--json", "--config", rules, path],
+    "semgrep", args,
     { timeout: 30 * 1000 }
   );
 


### PR DESCRIPTION
For my use case, having multiple rule sets like `semgrep --config "p/ci" --config "p/jwt"` show errors in VS Code would be great. Right now I need to go to the CLI and run all the rulesets, or toggle between different ones in the settings.json for my project. 

This change allows a `rules` setting to include as many URLs/paths as needed and passes each as a `--config` argument. 