### PR TITLE
Let `python3` locate `semgrep` module rather than relying on `semgrep` executable being in PATH

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,9 +10,9 @@ export const synthesizePatterns = async (
 ): Promise<vscode.QuickPickItem[]> => {
   let results: any[] | null = null;
   for (const range of ranges) {
-    const args = ["--quiet", "--synthesize-patterns", range, path];
+    const args = ["-m", "semgrep", "--quiet", "--synthesize-patterns", range, path];
     try {
-      var { stdout, stderr } = await execFileAsync("semgrep", args, {
+      var { stdout, stderr } = await execFileAsync("python3", args, {
         timeout: 30 * 1000,
         encoding: "utf-8",
         shell: true,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,8 +71,8 @@ export const checkFile = async (
   rules: string
 ): Promise<vscode.Diagnostic[]> => {
   const { stdout, stderr } = await execFileAsync(
-    "semgrep",
-    ["--json", "--config", rules, path],
+    "python3",
+    ["-m", "semgrep", "--json", "--config", rules, path],
     { timeout: 30 * 1000 }
   );
 
@@ -96,7 +96,7 @@ export const checkFile = async (
 
 export const getVersion = async (): Promise<string | undefined> => {
   try {
-    var { stdout, stderr } = await execFileAsync("semgrep", ["--version"], {
+    var { stdout, stderr } = await execFileAsync("python3", ["-m", "semgrep", "--version"], {
       timeout: 3 * 1000,
     });
   } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,9 +10,9 @@ export const synthesizePatterns = async (
 ): Promise<vscode.QuickPickItem[]> => {
   let results: any[] | null = null;
   for (const range of ranges) {
-    const args = ["-m", "semgrep", "--quiet", "--synthesize-patterns", range, path];
+    const args = ["--quiet", "--synthesize-patterns", range, path];
     try {
-      var { stdout, stderr } = await execFileAsync("python3", args, {
+      var { stdout, stderr } = await execFileAsync("python3", ["-m", "semgrep"].concat(args), {
         timeout: 30 * 1000,
         encoding: "utf-8",
         shell: true,


### PR DESCRIPTION
On macOS, VS Code is normally launched by Launch Services, which doesn't consult any shell runtime configuration, and thus doesn't get any `PATH` customization from RC dotfiles. Since macOS doesn't add the Python 3's `site.USER_BASE`/bin to the default `PATH` at system login, if the user installed Semgrep using `python3 -m pip install --user semgrep` (or installed it as a non-admin user, which would cause `pip` to default to the user install directory), then the parent directory of `semgrep` (e.g., ~/Library/Python/3.9/bin) won't be in the `PATH`. Because of this, it won't be in TypeScript's `process.env.PATH`, so it won't be found by `execFile`, and hence not by `execFileAsync` in `cli.ts`, thus (at least the macOS case of) issue #12. 

Tough I haven't tested this in WSL, I suspect roughly the same pattern reasoning applies in that case as well. 

To address this, rather than relying on `semgrep` being in the `PATH`, to avoid having to go looking in the Python user install directory within `semgrep-vscode`, I suggest running `semgrep` as a `python3` module instead. Because the Python 3 interpreter already checks the Python user install directory, it will find `semgrep` whether installed system-wide or in the user install directory, which should solve #12. 

I've tested this the latest VS Code on macOS Catalina, and it seems to solve the issue for me. Perhaps one of those reporting the same issue in WSL could test this on Windows?