### PR TITLE
remove brew as a supported installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ You can do so with
 pip install semgrep
 ```
 
-or
-
-```sh
-brew install semgrep
-```
-
-on macOS. For other installation instructions, see the [Semgrep README](https://github.com/returntocorp/semgrep#installation).
+For other installation instructions, see the [Semgrep README](https://github.com/returntocorp/semgrep#getting-started).
 
 ## Configuration
 


### PR DESCRIPTION
Addresses part of the confusion that lead to #3 and #12 being opened.