### PR TITLE
Add CLI version check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "semgrep",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "semgrep",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "dependencies": {
         "@types/node-fetch": "^2.5.7",
         "lint-staged": "^13.0.3",
         "node-fetch": "^2.6.0",
+        "semver": "^7.5.0",
         "vscode-jsonrpc": "^6.0.0",
         "vscode-languageclient": "^8.0.1",
         "which": "^2.0.2"
@@ -19,6 +20,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^14.0.27",
+        "@types/semver": "^7.3.13",
         "@types/vscode": "1.66.0",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^3.8.0",
@@ -232,6 +234,12 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
     },
     "node_modules/@types/vscode": {
       "version": "1.66.0",
@@ -2623,9 +2631,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3451,6 +3459,12 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
     },
     "@types/vscode": {
       "version": "1.66.0",
@@ -5154,9 +5168,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^14.0.27",
+    "@types/semver": "^7.3.13",
     "@types/vscode": "1.66.0",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
@@ -171,6 +172,7 @@
     "@types/node-fetch": "^2.5.7",
     "lint-staged": "^13.0.3",
     "node-fetch": "^2.6.0",
+    "semver": "^7.5.0",
     "vscode-jsonrpc": "^6.0.0",
     "vscode-languageclient": "^8.0.1",
     "which": "^2.0.2"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,4 @@ export const DEFAULT_RULESET = "p/r2c";
 export const LSP_LOG_FILE = "semgrep_lsp.log";
 export const VSCODE_CONFIG_KEY = "semgrep";
 export const VSCODE_EXT_NAME = CLIENT_NAME;
+export const MIN_VERSION = ">=1.21.0"; // Minimum semgrep version required for this extension


### PR DESCRIPTION
Add a CLI version check, and don't load the extension if it's an older semgrep version. I tried seeing what it takes to be backwards compatible, but the tech debt doesn't feel worth it. We'd have to have dynamic settings and commands based on the version, which feels gross to me.

### Security

- [X] Change has security implications (if so, ping the security team)
