### PR TITLE
Send metrics to semgrep-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,6 @@
           "type": "string",
           "default": "semgrep"
         },
-        "semgrep.logging": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "description": "Enable logging for the extension and the LSP server."
-        },
         "semgrep.scan.configuration": {
           "type": "array",
           "items": {
@@ -127,19 +121,6 @@
           "type": "boolean",
           "default": true,
           "description": "Only scan lines changed since the last commit"
-        },
-        "semgrep.metrics": {
-          "type": "string",
-          "default": "on",
-          "items": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "on",
-              "off"
-            ]
-          },
-          "description": "Enable or disable metrics collection. Auto will only report metrics when rules are pulled from the registry"
         }
       }
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,8 +17,8 @@ export class Config {
     return this.cfg.get<T>(path);
   }
 
-  get logging(): boolean {
-    return this.cfg.get<boolean>("logging") ?? false;
+  get trace(): boolean {
+    return this.cfg.get<string>("trace.server") == "verbose";
   }
 
   get path(): string {
@@ -67,13 +67,13 @@ export class Environment {
   static async create(context: ExtensionContext): Promise<Environment> {
     const config = await Environment.loadConfig(context);
     const channel = window.createOutputChannel(VSCODE_EXT_NAME);
-    const logger = new Logger(config.logging, channel);
+    const logger = new Logger(config.trace, channel);
     return new Environment(context, config, channel, logger);
   }
 
   static async loadConfig(context: ExtensionContext): Promise<Config> {
     const config = new Config();
-    if (config.logging) {
+    if (config.trace) {
       await Environment.initLogDir(context);
     }
 
@@ -87,7 +87,7 @@ export class Environment {
   async reloadConfig(): Promise<Environment> {
     // Reload configuration
     this.config = await Environment.loadConfig(this.context);
-    this.logger.enableLogger(this.config.logging);
+    this.logger.enableLogger(this.config.trace);
     return this;
   }
 

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -74,7 +74,7 @@ function semgrepCmdLineOpts(env: Environment): string[] {
   cmdlineOpts.push(...["lsp"]);
 
   // Logging
-  if (env.config.logging) {
+  if (env.config.trace) {
     cmdlineOpts.push(...["--debug"]);
   }
 
@@ -107,12 +107,26 @@ async function lspOptions(
     debug: run,
   };
   env.logger.log(`Semgrep LSP server configuration := ${JSON.stringify(run)}`);
+  const config = { ...env.config.cfg };
+  const metrics = {
+    machineId: vscode.env.machineId,
+    isNewAppInstall: vscode.env.isNewAppInstall,
+    sessionId: vscode.env.sessionId,
+    extensionVersion: env.context.extension.packageJSON.version,
+    extensionType: "vscode",
+    enabled: vscode.env.isTelemetryEnabled,
+  };
+  const initializationOptions = {
+    metrics: metrics,
+    ...config,
+  };
+  env.logger.log(`Semgrep Initializaiton Options := ${initializationOptions}`);
   const clientOptions: LanguageClientOptions = {
     diagnosticCollectionName: DIAGNOSTIC_COLLECTION_NAME,
     // TODO: should we limit to support languages and keep the list manually updated?
     documentSelector: [{ language: "*", scheme: "file" }],
     outputChannel: env.channel,
-    initializationOptions: env.config.cfg,
+    initializationOptions: initializationOptions,
   };
 
   return [serverOptions, clientOptions];

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -120,7 +120,7 @@ async function lspOptions(
     metrics: metrics,
     ...config,
   };
-  env.logger.log(`Semgrep Initializaiton Options := ${initializationOptions}`);
+  env.logger.log(`Semgrep Initialization Options := ${initializationOptions}`);
   const clientOptions: LanguageClientOptions = {
     diagnosticCollectionName: DIAGNOSTIC_COLLECTION_NAME,
     // TODO: should we limit to support languages and keep the list manually updated?


### PR DESCRIPTION
Send the cool telemetry metrics VSCode gives us to the cli so we can report them.

### Security

- [ ] Change has security implications (if so, ping the security team)
