### PR TITLE
Small fix to make commands order better by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,6 @@
     },
     "commands": [
       {
-        "command": "semgrep.login",
-        "title": "Semgrep: Sign in"
-      },
-      {
         "command": "semgrep.scanWorkspace",
         "title": "Semgrep: Scan changed files in workspace"
       },
@@ -52,12 +48,16 @@
         "title": "Semgrep: Scan all files in workspace"
       },
       {
+        "command": "semgrep.login",
+        "title": "Semgrep: Sign in"
+      },      
+      {
         "command": "semgrep.logout",
         "title": "Semgrep: Sign out"
       },
       {
         "command": "semgrep.refreshRules",
-        "title": "Semgrep: Refresh rules"
+        "title": "Semgrep: Update rules"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Use of Update instead of Refresh stops making it the first item when using cmd+P

### Security

- [ ] Change has security implications (if so, ping the security team)
