### PR TITLE
Change defaults to sensible value

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,13 +114,28 @@
         },
         "semgrep.scan.maxTargetBytes": {
           "type": "integer",
-          "default": 0,
+          "default": 1000000,
           "description": "Maximum size of target in bytes to scan."
+        },
+        "semgrep.scan.timeout": {
+          "type": "integer",
+          "default": 30,
+          "description": "Maximum time to scan in seconds."
+        },
+        "semgrep.scan.timeoutThreshold": {
+          "type": "integer",
+          "default": 3,
+          "description": "Maximum number of rules that can timeout on a file before the file is skipped. If set to 0 will not have limit. Defaults to 3."
         },
         "semgrep.scan.onlyGitDirty": {
           "type": "boolean",
           "default": true,
           "description": "Only scan lines changed since the last commit"
+        },
+        "semgrep.metrics.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable or disable metrics collection."
         }
       }
     }


### PR DESCRIPTION
Having no file size limit would cause scans to go forever, and so now these match the defaults for semgrep-cli
### Security

- [ ] Change has security implications (if so, ping the security team)
