### PR TITLE
Add restart command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,7 @@
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
       "outFiles": ["${workspaceRoot}/out/**/*.js"],
-      "preLaunchTask": {
-        "type": "npm",
-        "script": "esbuild"
-      }
+      "preLaunchTask": "watch-build"
     },
     {
       "name": "Extension Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,8 +13,26 @@
     },
     {
       "type": "npm",
-      "script": "watch",
+      "label": "watch-build",
+      "script": "esbuild-watch",
       "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "fileLocation": "relative",
+        "pattern": {
+          "regexp": "^([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(error|warning|info)\\s+(TS\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "location": 2,
+          "severity": 3,
+          "code": 4,
+          "message": 5
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "\\[watch\\] build started.*",
+          "endsPattern": "\\[watch\\] build finished.*"
+        }
+      },
       "group": {
         "kind": "build",
         "isDefault": true
@@ -22,8 +40,7 @@
       "presentation": {
         "panel": "dedicated",
         "reveal": "never"
-      },
-      "problemMatcher": ["$tsc-watch"]
+      }
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the "semgrep-vscode" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `Semgrep: Restart Language Server` command, to restart language server
+
+### Changed
+
+- Diagnostic information should now be properly rendered in markdown
+
 ## v1.4.1 - 2023-06-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
         "title": "Semgrep Search: Clear",
         "icon": "$(search-remove)",
         "when": "semgrep.cli.minor >= 25 || config.semgrep.ignoreCliVersion"
+      },
+      {
+        "command": "semgrep.restartLanguageServer",
+        "title": "Semgrep: Restart Language Server"
       }
     ],
     "configuration": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,7 @@ import { window, workspace } from "vscode";
 import { LSP_LOG_FILE, VSCODE_CONFIG_KEY, VSCODE_EXT_NAME } from "./constants";
 import { DEFAULT_LSP_LOG_URI, Logger } from "./utils";
 import { SemgrepSearchProvider } from "./searchResultsTree";
+import { LanguageClient } from "vscode-languageclient/node";
 
 export class Config {
   get cfg(): WorkspaceConfiguration {
@@ -28,8 +29,9 @@ export class Config {
 }
 
 export class Environment {
-  _config: Config = new Config();
+  private _config: Config = new Config();
   semgrep_log: Uri = DEFAULT_LSP_LOG_URI;
+  private _client: LanguageClient | null = null;
 
   private constructor(
     readonly context: ExtensionContext,
@@ -52,6 +54,7 @@ export class Environment {
   }
 
   get loggedIn(): boolean {
+    this.logger.log("HAFAWAD");
     return this.context.globalState.get("loggedIn", false);
   }
 
@@ -74,6 +77,15 @@ export class Environment {
     this.context.globalState.update("newInstall", val);
   }
 
+  set client(client: LanguageClient | null) {
+    this._client = client;
+  }
+  get client() {
+    if (!this._client) {
+      window.showWarningMessage("Semgrep Language Server not active");
+    }
+    return this._client;
+  }
   static async create(context: ExtensionContext): Promise<Environment> {
     const config = await Environment.loadConfig(context);
     const channel = window.createOutputChannel(VSCODE_EXT_NAME);

--- a/src/env.ts
+++ b/src/env.ts
@@ -54,7 +54,6 @@ export class Environment {
   }
 
   get loggedIn(): boolean {
-    this.logger.log("HAFAWAD");
     return this.context.globalState.get("loggedIn", false);
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,7 @@ import { createStatusBar } from "./statusBar";
 import { ConfigurationChangeEvent, ExtensionContext } from "vscode";
 
 let global_env: Environment | null = null;
-// needed for deactivate
-let global_client: LanguageClient | null = null;
+
 async function initEnvironment(
   context: ExtensionContext
 ): Promise<Environment> {
@@ -24,69 +23,53 @@ async function createOrUpdateEnvironment(
   return global_env ? global_env.reloadConfig() : initEnvironment(context);
 }
 
-export async function activate(
-  context: ExtensionContext
-): Promise<LanguageClient | null> {
+export async function activate(context: ExtensionContext): Promise<void> {
   const env: Environment = await createOrUpdateEnvironment(context);
 
-  const client = await activateLsp(env);
-  global_client = client;
-  const statusBar = createStatusBar();
-  if (client) {
-    registerCommands(env, client);
-    statusBar.show();
-    vscode.window.registerTreeDataProvider(
-      "semgrep-search-results",
-      env.searchView
+  await activateLsp(env);
+  if (!env.client) {
+    vscode.window.showErrorMessage(
+      "Semgrep Extension failed to activate, please check output"
     );
-    // Handle configuration changes
-    context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration(
-        async (event: ConfigurationChangeEvent) => {
-          if (event.affectsConfiguration(VSCODE_CONFIG_KEY)) {
-            await env.reloadConfig();
-            client.sendNotification("workspace/didChangeConfiguration", {
-              settings: env.config.cfg,
-            });
-          }
-        }
-      )
-    );
-    await vscode.commands.executeCommand("semgrep.loginStatus");
-    vscode.commands.executeCommand("semgrep.loginNudge");
-    if (env.newInstall) {
-      env.newInstall = false;
-      const selection = await vscode.window.showInformationMessage(
-        "Semgrep Extension succesfully installed. Would you like to try performing a full workspace scan (may take longer on bigger workspaces)?",
-        "Scan Full Workspace",
-        "Dismiss"
-      );
-      if (selection == "Scan Full Workspace") {
-        vscode.commands.executeCommand("semgrep.scanWorkspaceFull");
-      }
-    }
-  } else {
-    vscode.window.showErrorMessage("Failed to load Semgrep Extension");
+    return;
   }
-  vscode.window.activeTextEditor;
-  return client;
+  const statusBar = createStatusBar();
+  registerCommands(env);
+  statusBar.show();
+  vscode.window.registerTreeDataProvider(
+    "semgrep-search-results",
+    env.searchView
+  );
+  // Handle configuration changes
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(
+      async (event: ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration(VSCODE_CONFIG_KEY)) {
+          await env.reloadConfig();
+          restartLsp(env);
+        }
+      }
+    )
+  );
+  await vscode.commands.executeCommand("semgrep.loginStatus");
+  vscode.commands.executeCommand("semgrep.loginNudge");
+  if (env.newInstall) {
+    env.newInstall = false;
+    const selection = await vscode.window.showInformationMessage(
+      "Semgrep Extension succesfully installed. Would you like to try performing a full workspace scan (may take longer on bigger workspaces)?",
+      "Scan Full Workspace",
+      "Dismiss"
+    );
+    if (selection == "Scan Full Workspace") {
+      vscode.commands.executeCommand("semgrep.scanWorkspaceFull");
+    }
+  }
 }
 
 export async function deactivate(): Promise<void> {
-  if (global_client) {
-    await deactivateLsp(global_env, global_client);
+  if (global_env?.client) {
+    await deactivateLsp(global_env);
   }
   global_env?.dispose();
   global_env = null;
-}
-
-export async function restart(
-  context: ExtensionContext,
-  client: LanguageClient
-): Promise<void> {
-  const env: Environment = await createOrUpdateEnvironment(context);
-
-  env.logger.log("Restarting language client...");
-  await restartLsp(env, client);
-  env.logger.log("Restarted language client...");
 }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -7,7 +7,7 @@ export function createStatusBar(): vscode.StatusBarItem {
   const statusBarCommand: vscode.Command = {
     title: "",
     command: "workbench.action.quickOpen",
-    arguments: [">Semgrep"],
+    arguments: [">Semgrep:"],
   };
   statusBar.command = statusBarCommand;
   statusBar.text = "$(semgrep-icon)";


### PR DESCRIPTION
Added command to restart lsp. Also fixed issue where diagnostics were not rendering markdown. For development, we now will properly watch + reload extension source code when running debugger.

## Test plan

Just manually checked

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [X] Documentation is up-to-date
- [X] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
