### PR TITLE
feat: hover for ast viewing

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
           "default": true,
           "description": "Only scan lines changed since the last commit"
         },
+        "semgrep.doHover": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable hovering for AST node viewing (requires restart)"
+        },
         "semgrep.metrics.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## What:
This PR adds in support on the VS Code side, to be able to display the closest Generic AST node upon hover.

Companion to https://github.com/returntocorp/semgrep/pull/8142

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [] Documentation is up-to-date
- [] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
