### PR TITLE
respect local env vars

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -63,6 +63,7 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
     }
     server_path = `${globalstorage_path}/bin/semgrep`;
     env_vars = {
+      ...process.env,
       PYTHONUSERBASE: globalstorage_path,
     };
   }


### PR DESCRIPTION
Added `process.env` back to env_vars (as is default - https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback), ensuring we respect important environment variables such as `REQUESTS_CA_BUNDLE` - hopefully fixing #62.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Ran tests locally (VSCode tests cannot run in CI)
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
