### PR TITLE
fix: Typescript is bad at types

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -134,7 +134,7 @@ async function lspOptions(
   const config = Object.create(env.config.cfg);
   const metrics = {
     machineId: vscode.env.machineId,
-    isNewAppInstall: true,
+    isNewAppInstall: env.newInstall,
     sessionId: vscode.env.sessionId,
     extensionVersion: env.context.extension.packageJSON.version,
     extensionType: "vscode",

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -131,10 +131,10 @@ async function lspOptions(
   env.logger.log(
     `Semgrep LSP server configuration := ${JSON.stringify(server)}`
   );
-  const config = { ...env.config.cfg };
+  const config = Object.create(env.config.cfg);
   const metrics = {
     machineId: vscode.env.machineId,
-    isNewAppInstall: env.newInstall,
+    isNewAppInstall: true,
     sessionId: vscode.env.sessionId,
     extensionVersion: env.context.extension.packageJSON.version,
     extensionType: "vscode",


### PR DESCRIPTION
Previously, the configuration object was not being converted to an object, so really it was dict like type, so when we set the metrics field it never was sent to the language server :/. This fixes that.

## Test plan

Check the output tab to verify these metrics are being sent

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
