### PR TITLE
Revert "fix: Typescript is bad at types"

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -131,7 +131,7 @@ async function lspOptions(
   env.logger.log(
     `Semgrep LSP server configuration := ${JSON.stringify(server)}`
   );
-  const config = Object.create(env.config.cfg);
+  const config = { ...env.config.cfg };
   const metrics = {
     machineId: vscode.env.machineId,
     isNewAppInstall: env.newInstall,


### PR DESCRIPTION
Reverts returntocorp/semgrep-vscode#68

This breaks things really bad. I have no idea why but diagnostic reporting becomes absolutely trashed :/.