### PR TITLE
better debug option

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -109,22 +109,24 @@ async function lspOptions(
   if (server.options) {
     server.options.cwd = cwd;
   }
-  const cmd = `"${server.command}" --version`;
-  const version = await execShell(cmd, server.options?.env);
-  const minor = semver.minor(version);
-  const major = semver.major(version);
-  vscode.commands.executeCommand("setContext", "semgrep.cli.minor", minor);
-  vscode.commands.executeCommand("setContext", "semgrep.cli.major", major);
-  if (!semver.satisfies(version, MIN_VERSION)) {
-    vscode.window.showErrorMessage(
-      `The Semgrep Extension requires a Semgrep CLI version ${MIN_VERSION}, the current installed version is ${version}, please upgrade.`
-    );
-    return [null, null];
-  }
-  if (!semver.satisfies(version, LATEST_VERSION)) {
-    vscode.window.showWarningMessage(
-      `Some features of the Semgrep Extension require a Semgrep CLI version ${LATEST_VERSION}, but the current installed version is ${version}, some features may be disabled, please upgrade.`
-    );
+  if (!env.config.cfg.get("ignoreCliVersion")) {
+    const cmd = `"${server.command}" --version`;
+    const version = await execShell(cmd, server.options?.env);
+    const minor = semver.minor(version);
+    const major = semver.major(version);
+    vscode.commands.executeCommand("setContext", "semgrep.cli.minor", minor);
+    vscode.commands.executeCommand("setContext", "semgrep.cli.major", major);
+    if (!semver.satisfies(version, MIN_VERSION)) {
+      vscode.window.showErrorMessage(
+        `The Semgrep Extension requires a Semgrep CLI version ${MIN_VERSION}, the current installed version is ${version}, please upgrade.`
+      );
+      return [null, null];
+    }
+    if (!semver.satisfies(version, LATEST_VERSION)) {
+      vscode.window.showWarningMessage(
+        `Some features of the Semgrep Extension require a Semgrep CLI version ${LATEST_VERSION}, but the current installed version is ${version}, some features may be disabled, please upgrade.`
+      );
+    }
   }
 
   const serverOptions: ServerOptions = server;


### PR DESCRIPTION
This makes it so it's easy to use the osemgrep binary directly for debugging purposes
PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Ran tests locally (VSCode tests cannot run in CI)
- [X] Documentation is up-to-date
- [X] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
