### PR TITLE
feat: new policy view with login CTA

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,8 +217,19 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "semgrep.view.policy",
+        "contents": "[Sign in](command:semgrep.login)",
+        "when": "!semgrep.loggedIn"
+      }
+    ],
     "views": {
       "semgrep-sidebar": [
+        {
+          "id": "semgrep.view.policy",
+          "name": "Policy Configuration"
+        },
         {
           "type": "webview",
           "id": "semgrep.searchView",

--- a/src/env.ts
+++ b/src/env.ts
@@ -69,12 +69,17 @@ export class Environment {
     setSentryContext(this);
   }
 
+  loginEvent?: vscode.EventEmitter<void> = undefined;
+
   get loggedIn(): boolean {
     return this.context.globalState.get("loggedIn", false);
   }
 
   set loggedIn(val: boolean) {
     vscode.commands.executeCommand("setContext", "semgrep.loggedIn", val);
+    if (this.loginEvent) {
+      this.loginEvent.fire();
+    }
     this.context.globalState.update("loggedIn", val);
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+
 import type { ConfigurationChangeEvent, ExtensionContext } from "vscode";
 import { registerCommands } from "./commands";
 import { VSCODE_CONFIG_KEY } from "./constants";
@@ -7,6 +8,7 @@ import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { SemgrepDocumentProvider } from "./showAstDocument";
 import { createStatusBar } from "./statusBar";
 import { initTelemetry, stopTelemetry } from "./telemetry/telemetry";
+import { SemgrepPolicyViewProvider } from "./views/policy";
 import { SemgrepHelpProvider } from "./views/support";
 import { SemgrepSearchWebviewProvider } from "./views/webview";
 
@@ -35,8 +37,7 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
     return;
   }
   const statusBar = createStatusBar();
-  context.subscriptions.push(statusBar);
-  registerCommands(env).forEach((d) => context.subscriptions.push(d));
+  context.subscriptions.push(statusBar, ...registerCommands(env));
   statusBar.show();
 
   // register stuff for search webview
@@ -58,6 +59,12 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
         context.extensionUri,
         context.extension.packageJSON.version,
       ),
+    ),
+  );
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider(
+      SemgrepPolicyViewProvider.viewType,
+      new SemgrepPolicyViewProvider(context.extensionUri, env),
     ),
   );
 

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -1,13 +1,17 @@
-import cp from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import * as cp from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as semver from "semver";
 import * as vscode from "vscode";
 import {
   type Executable,
   LanguageClient,
   type LanguageClientOptions,
+  MessageType,
+  type NotificationHandler,
   type ServerOptions,
+  ShowMessageNotification,
+  ShowMessageParams,
   TransportKind,
 } from "vscode-languageclient/node";
 import type { NotificationHandler0 } from "vscode-languageserver";
@@ -246,7 +250,6 @@ async function start(env: Environment): Promise<void> {
     env.logger.log("Rules loaded");
     env.emitRulesRefreshedEvent();
   };
-
   // Register handlers here
   c.onNotification(rulesRefreshed, notificationHandler);
   c.onTelemetry((e) => {

--- a/src/views/policy.ts
+++ b/src/views/policy.ts
@@ -1,0 +1,43 @@
+import * as vscode from "vscode";
+import type { Environment } from "../env";
+
+export class SemgrepPolicyViewProvider
+  implements vscode.TreeDataProvider<PolicyItem>
+{
+  public static readonly viewType = "semgrep.view.policy";
+
+  //  [ + add more? ]
+  // root
+  //  \ connect to org (log in)    OR     <ORG NAME>'s policy
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly env: Environment,
+  ) {
+    env.loginEvent = this._onDidChangeTreeData;
+  }
+
+  getTreeItem(element: PolicyItem): PolicyItem {
+    return element;
+  }
+
+  getChildren(
+    element?: PolicyItem | undefined,
+  ): vscode.ProviderResult<PolicyItem[]> {
+    if (!element) {
+      if (this.env.loggedIn) {
+        const login_status = new PolicyItem("Using your organization's policy");
+        login_status.iconPath = new vscode.ThemeIcon("cloud-download");
+        return [login_status];
+      }
+      return [];
+    }
+    return [];
+  }
+
+  private _onDidChangeTreeData: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData: vscode.Event<void> =
+    this._onDidChangeTreeData.event;
+}
+
+class PolicyItem extends vscode.TreeItem {}


### PR DESCRIPTION
The policy view is blank on logging in. This still version of this commit needs some imports updated. Planning on going through and reorganizing imports generally / improving autoformatting and then rebasing probably.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

| Logged out | Logged in |
|------------|-----------|
|<img width="268" alt="image" src="https://github.com/user-attachments/assets/663f7781-3231-4821-b338-50f42e1dfd06">|<img width="272" alt="image" src="https://github.com/user-attachments/assets/29c261e4-8866-4d0f-b3bb-27c86255839e">|