### PR TITLE
feat: only show sign in/out as relevant

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,16 @@
           "when": "editorTextFocus",
           "group": "navigation"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "semgrep.login",
+          "when": "!semgrep.loggedIn"
+        },
+        {
+          "command": "semgrep.logout",
+          "when": "semgrep.loggedIn"
+        }
       ]
     },
     "walkthroughs": [


### PR DESCRIPTION
This uses the new context key for login status. However, since that context key is still frequently stale due how the current login flow works with our LSP extensions, we should hold off on merging this one until I clean that up too.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
