### PR TITLE
feat: consume new login flow

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,8 +4,8 @@ import type { Environment } from "./env";
 import { restartLsp } from "./lsp";
 import {
   type SearchParams,
-  login,
   loginFinish,
+  loginStart,
   loginStatus,
   logout,
   refreshRules,
@@ -61,10 +61,13 @@ export function registerCommands(env: Environment): Disposable[] {
     /************/
 
     vscode.commands.registerCommand("semgrep.login", async () => {
-      const result = await env.client?.sendRequest(login);
+      const result = await env.client?.sendRequest(loginStart);
       if (result) {
         vscode.env.openExternal(vscode.Uri.parse(result.url));
-        env.client?.sendNotification(loginFinish, result);
+        const status = await env.client?.sendRequest(loginFinish, result);
+        if (status) {
+          env.loggedIn = status.loggedIn;
+        }
       }
     }),
 

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -20,12 +20,12 @@ export const scanWorkspace = new lc.NotificationType<ScanWorkspaceParams>(
   "semgrep/scanWorkspace",
 );
 
-export interface LoginParams {
+export interface LoginStartResponse {
   url: string;
   sessionId: string;
 }
 
-export interface LoginStatusParams {
+export interface LoginStatusResponse {
   loggedIn: boolean;
 }
 
@@ -55,13 +55,15 @@ export interface LspErrorParams {
   stack: string;
 }
 
-export const login = new lc.RequestType0<LoginParams | null, void>(
-  "semgrep/login",
+export const loginStart = new lc.RequestType0<LoginStartResponse | null, void>(
+  "semgrep/loginStart",
 );
 
-export const loginFinish = new lc.NotificationType<LoginParams>(
-  "semgrep/loginFinish",
-);
+export const loginFinish = new lc.RequestType<
+  LoginStartResponse,
+  LoginStatusResponse,
+  void
+>("semgrep/loginFinish");
 
 export const logout = new lc.NotificationType("semgrep/logout");
 
@@ -75,9 +77,10 @@ export const workspaceRules = new lc.RequestType0<any[], void>(
   "semgrep/workspaceRules",
 );
 
-export const loginStatus = new lc.RequestType0<LoginStatusParams | null, void>(
-  "semgrep/loginStatus",
-);
+export const loginStatus = new lc.RequestType0<
+  LoginStatusResponse | null,
+  void
+>("semgrep/loginStatus");
 
 export const search = new lc.RequestType<LspSearchParams, SearchResults, void>(
   "semgrep/search",


### PR DESCRIPTION
This should let us avoid stale state caused by the prior implementation, which handled the "finish" step as a notification, rather than as a request.

Do not merge without corresponding CLI API version.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
