### PR TITLE
fix: Use semgrep from PATH if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefer native executable on Windows instead of lspjs
 
+- Extension now uses installed semgrep from the PATH correctly, before trying
+  to use the bundled semgrep executable.
+
 ## v1.9.0 - 2024-08-28
 
 ### Added

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -49,20 +49,21 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
   // First, check if the user has set the path to the Semgrep binary, use that always
   if (env.config.path.length > 0) {
     serverPath = env.config.path;
-    // check if the path exists
-    if (!fs.existsSync(serverPath)) {
-      // try checking if its a binary in the PATH
-      serverPath = which.sync("semgrep", { nothrow: true });
-    }
-    // Only check the version if we're not using the packaged version
-    // This is to avoid us releasing a new version of the extension late and then people get annoying popups
-    if (!env.config.cfg.get("ignoreCliVersion") && serverPath) {
-      const version = await execShell(serverPath, ["--version"]);
-      const semVersion = new semver.SemVer(version);
-      checkCliVersion(semVersion);
-      env.semgrepVersion = version;
-      await env.reloadConfig();
-    }
+  }
+
+  // check if the path exists
+  if (!serverPath || !fs.existsSync(serverPath)) {
+    // try checking if its a binary in the PATH
+    serverPath = which.sync("semgrep", { nothrow: true });
+  }
+  // Only check the version if we're not using the packaged version
+  // This is to avoid us releasing a new version of the extension late and then people get annoying popups
+  if (!env.config.cfg.get("ignoreCliVersion") && serverPath) {
+    const version = await execShell(serverPath, ["--version"]);
+    const semVersion = new semver.SemVer(version);
+    checkCliVersion(semVersion);
+    env.semgrepVersion = version;
+    await env.reloadConfig();
   }
 
   if (!serverPath) {


### PR DESCRIPTION
Previously, we tried to use semgrep from the PATH only if the user configured an incorrect path value. This commit changes that to use semgrep on PATH even when the user has not specified a path for semgrep.

Test plan: 

Configure the extension to run semgrep in the verbose/debug mode and check that the executable used is the correct one. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
