### PR TITLE
feat(win): Switch to using the native executable on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Prefer native executable on Windows instead of lspjs
+
 ## v1.9.0 - 2024-08-28
 
 ### Added

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -232,6 +232,9 @@ async function lspOptions(
 }
 
 async function start(env: Environment): Promise<void> {
+  // TODO: Remove when semgrep is no longer experimental on Windows.
+  if (process.platform === "win32") process.env.SEMGREP_FORCE_INSTALL = "1";
+
   // Compute LSP server and client options
   const [serverOptions, clientOptions] = await lspOptions(env);
 

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -168,7 +168,7 @@ function serverOptionsJs(env: Environment): ServerOptions {
     },
   };
   vscode.window.showWarningMessage(
-    "Semgrep Extension is using the experimental JS LSP server, this is due to the current platform being Windows, or the setting 'semgrep.useJS' being set to true. There may be bugs or performance issues!",
+    "The Semgrep Extension is using the experimental JS LSP server, this is due to not finding the Semgrep executable, or of 'semgrep.useJS' being set to true. There may be bugs or performance issues!",
   );
   return serverOptionsJs;
 }
@@ -217,10 +217,8 @@ async function lspOptions(
   };
 
   let serverOptions;
-  // if we're not on windows or not using JS, we can use the CLI
-  if (process.platform !== "win32") {
-    serverOptions = await serverOptionsCli(env);
-  }
+  // if we're not using JS, we can use the native binary
+  serverOptions = await serverOptionsCli(env);
   if (!serverOptions || env.config.get("useJS")) {
     serverOptions = serverOptionsJs(env);
   }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -133,6 +133,11 @@ async function serverOptionsCli(
   env.logger.log(
     `Semgrep LSP server configuration := ${JSON.stringify(server, null, 2)}`,
   );
+  if (process.platform === "win32") {
+    vscode.window.showWarningMessage(
+      "The Semgrep Extension on Windows is experimental. Please report any issues here: https://github.com/semgrep/semgrep-vscode/issues",
+    );
+  }
   return serverOptions;
 }
 


### PR DESCRIPTION
Previously, we always used lspjs on Windows, without any way to use the
native executable on Windows. This commit changes the behavior to be
similar to other platforms where we try to use the native executable if
we are able to find it. Note that the native binary executable is not
yet packaged with the Windows extension, and so we would fallback to
trying to use lspjs if a semgrep installation isn't discovered.

Also, displays a user warning about Windows support being experimental. 

Test plan:
Run the extension in debug/verbose mode and note the executable being used.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
