### PR TITLE
release: copy exe and DLLs into Windows extension

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,9 +44,14 @@ jobs:
           role-duration-seconds: 900,
           role-session-name: "semgrep-ide-integration-deploy"
           aws-region: "us-west-2"
+      - uses: actions/setup-python@v5
+        # setup Python/pip to download the Windows wheel for the DLLs
+        if: matrix.target == 'win32-x64'
+        with:
+          python-version: "3.11"
       - name: download osemgrep pro
-        # skip if windows
-        if: matrix.target != 'win32-x64' && matrix.target != 'win32-arm64'
+        # skip if windows ARM64, we don't build a compatible binary
+        if: matrix.target != 'win32-arm64'
         run: ./download-osemgrep-pro.sh ${{ matrix.target }}
       - name: install vsix
         run: npm install -g @vscode/vsce

--- a/download-osemgrep-pro.sh
+++ b/download-osemgrep-pro.sh
@@ -6,20 +6,36 @@ case "${uname}" in
     linux-arm64*)   machine=linux-arm64;;
     darwin-x64*)   machine=osx;;
     darwin-arm64)    machine=osx-m1;;
+    win32-x64*)   machine=windows;;
     *)    machine=manylinux;;
 esac
 # NOT the same as the semgrep version!!!!
 release_char_count=$(echo "release-" | wc -c)
 OSEMGREP_PRO_VERSION=$(cat ./semgrep-version | cut -c $((release_char_count))-)
 BINARY=semgrep-core-proprietary-${machine}-${OSEMGREP_PRO_VERSION}
+if [ "${machine}" = "windows" ]; then
+    EXT=".exe"
+else
+    EXT=""
+fi
 # Check if osemgrep-pro exists and if its a symlink then exit
-if [ -L dist/osemgrep-pro ]; then
+if [ -L dist/osemgrep-pro${EXT} ]; then
     echo "osemgrep-pro symlink exists, not downloading as you are most likely using a local version"
     exit 0
 fi
 mkdir -p dist
 echo "Downloading osemgrep-pro binary from S3 for version ${machine}-${OSEMGREP_PRO_VERSION}"
-aws s3 cp s3://deep-semgrep-artifacts/${BINARY} dist/osemgrep-pro
+aws s3 cp "s3://deep-semgrep-artifacts/${BINARY}${EXT}" dist/osemgrep-pro${EXT}
 echo "Downloaded osemgrep-pro binary"
-echo "Making osemgrep-pro binary executable"
-chmod +x dist/osemgrep-pro
+if [ "${machine}" = "windows" ]; then
+    echo "Downloading the Windows wheel for the DLLs"
+    PLATFORM="win_amd64"
+    pip download "semgrep==${OSEMGREP_PRO_VERSION}" --no-deps --platform ${PLATFORM} -d /tmp/
+    echo "Unzipping the Windows wheel"
+    unzip -q -o /tmp/"semgrep-${OSEMGREP_PRO_VERSION}"-*-${PLATFORM}.whl -d /tmp/
+    echo "Copying the DLLs to the dist directory"
+    cp -r /tmp/"semgrep-${OSEMGREP_PRO_VERSION}.data"/purelib/semgrep/bin/*.dll dist/
+else
+    echo "Making osemgrep-pro binary executable"
+    chmod +x dist/osemgrep-pro
+fi

--- a/semgrep-version
+++ b/semgrep-version
@@ -1,1 +1,1 @@
-release-1.110.0
+release-1.121.0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,9 @@ export const VSCODE_CONFIG_KEY = "semgrep";
 export const VSCODE_EXT_NAME = CLIENT_NAME;
 export const DIST_PATH = path.join(__dirname, "../dist");
 export const LSPJS_PATH = path.join(DIST_PATH, "lspjs/semgrep-lsp.js");
-export const DIST_BINARY_PATH = path.join(DIST_PATH, "osemgrep-pro");
+const DIST_BINARY_NAME =
+  process.platform === "win32" ? "osemgrep-pro.exe" : "osemgrep-pro";
+export const DIST_BINARY_PATH = path.join(DIST_PATH, DIST_BINARY_NAME);
 export const VERSION_PATH = path.join(__dirname, "../semgrep-version");
 
 export type VersionInfo = {


### PR DESCRIPTION
Bundle the `semgrep-core-proprietary` Windows executable into the extension like on other platforms. We don't build an ARM compatible binary and only download it on win32-x64 target.

On Windows, we also need the DLLs to be able to run the executable. The DLLs are available in the Python wheels uploaded to PyPI and we bundle them into the Windows extension.

Test plan: 

- Dry run of the publish action for this commit is available [here](https://github.com/semgrep/semgrep-vscode/actions/runs/14918203888)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

