### PR TITLE
fix: Prevent crashes on couple of commands from command palette

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -181,6 +181,12 @@ export function registerCommands(env: Environment): Disposable[] {
     vscode.commands.registerCommand(
       "semgrep.search",
       async (searchParams: SearchParams) => {
+        if (!searchParams) {
+          vscode.window.showErrorMessage(
+            "Semgrep Search by pattern can only be run via the Semgrep Sidebar.",
+          );
+          return;
+        }
         await handleSearch(env, searchParams);
       },
     ),
@@ -207,17 +213,15 @@ export function registerCommands(env: Environment): Disposable[] {
 
     vscode.commands.registerCommand(
       "semgrep.search.replace",
-      async ({
-        uri,
-        fix,
-        range,
-      }: {
-        uri: string;
-        fix: string;
-        range: vscode.Range;
-      }) => {
+      async (args: { uri?: string; fix?: string; range?: vscode.Range }) => {
+        if (!args?.uri || !args?.fix || !args?.range) {
+          vscode.window.showErrorMessage(
+            "Semgrep Semantic Replace can only be run via the Semgrep Sidebar.",
+          );
+          return;
+        }
         const edit = new vscode.WorkspaceEdit();
-        edit.replace(vscode.Uri.parse(uri), range, fix);
+        edit.replace(vscode.Uri.parse(args.uri), args.range, args.fix);
         await applyFixAndSave(edit);
       },
     ),

--- a/src/search.ts
+++ b/src/search.ts
@@ -129,8 +129,8 @@ export async function handleSearch(
   env: Environment,
   searchParams: SearchParams,
 ): Promise<void> {
-  env.scanID = searchParams.scanID;
   if (searchParams != null) {
+    env.scanID = searchParams.scanID;
     const results = await env.client?.sendRequest(
       search,
       searchParams.lspParams,


### PR DESCRIPTION
When run from the command palette (`Ctrl+Shift+P`), a couple of commands crash with an unhelpful error message. This commit adds a more helpful error message.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)
