### PR TITLE
Fix the invocation that obtains the semgrep version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extension now uses installed semgrep from the PATH correctly, before trying
   to use the bundled semgrep executable.
 
+### Fixed
+
+- Avoid extension activation error due to a failure of `osemgrep-pro --version`.
+
 ## v1.9.0 - 2024-08-28
 
 ### Added

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -59,7 +59,8 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
   // Only check the version if we're not using the packaged version
   // This is to avoid us releasing a new version of the extension late and then people get annoying popups
   if (!env.config.cfg.get("ignoreCliVersion") && serverPath) {
-    const version = await execShell(serverPath, ["--version"]);
+    // 'osemgrep --version' fails; not sure how intentional that is.
+    const version = await execShell(serverPath, ["show", "version"]);
     const semVersion = new semver.SemVer(version);
     checkCliVersion(semVersion);
     env.semgrepVersion = version;


### PR DESCRIPTION
`osemgrep --version` doesn't work. Maybe it should, I'm not sure, but this fixes a version check in the vscode extension that occurs when signing into semgrep.

Test plan:
1. somehow trigger a semgrep sign-in (not sure how I did that; could be a weekly thing), or maybe it happens when re-installing the extension.
2. hit the "sign-in" button.
3. We should not get the following error:

![image](https://github.com/user-attachments/assets/b3d64ac7-b137-433e-be50-dabd248036fb)


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
