### PR TITLE
Disable version check due to coupling between extension and CLI?

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,8 @@ export type VersionInfo = {
   min: SemVer;
 };
 
+// We used to have a CLI version check that used this function.
+// It's now unused but could be handy for troubleshooting. Keeping it for now.
 export async function getVersionInfo(): Promise<VersionInfo | undefined> {
   const url = "https://semgrep.dev/api/check-version";
   try {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -32,7 +32,6 @@ import {
   captureLspError,
   withSentryAsync,
 } from "./telemetry/sentry";
-import { checkCliVersion } from "./utils";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -61,7 +60,6 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
   if (!env.config.cfg.get("ignoreCliVersion") && serverPath) {
     const version = await execShell(serverPath, ["--version"]);
     const semVersion = new semver.SemVer(version);
-    checkCliVersion(semVersion);
     env.semgrepVersion = version;
     await env.reloadConfig();
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,9 @@ export class Logger {
 // of the extension, not of the CLI. VSCode does this for us already.
 // TODO: Should we simply disable this version check?
 //
+// Note that we are still interested in collecting stats about the extension
+// version that users are running but this doesn't seem to be done here.
+//
 export async function checkCliVersion(
   currentVersion: semver.SemVer,
 ): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,16 @@ export class Logger {
   }
 }
 
+// 1. Obtain from the semgrep.dev server the minimum recommended version
+//    for the CLI.
+// 2. Show a warning asking the user to upgrade their CLI.
+//
+// Unfortunately, the VSCode extension is bundled with the semgrep CLI.
+// I don't think we should encourage users to upgrade their CLI
+// independently from the VSCode extension code. We should check the version
+// of the extension, not of the CLI. VSCode does this for us already.
+// TODO: Should we simply disable this version check?
+//
 export async function checkCliVersion(
   currentVersion: semver.SemVer,
 ): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import * as semver from "semver";
 import { Uri } from "vscode";
 import type { OutputChannel } from "vscode";
 import * as vscode from "vscode";
-import { getVersionInfo } from "./constants";
 import type { ViewResults } from "./webviews/types/results";
 
 // Can't put this in constants for some reason??
@@ -26,49 +25,6 @@ export class Logger {
     if (this.enabled) {
       this.channel.appendLine(message);
     }
-  }
-}
-
-// 1. Obtain from the semgrep.dev server the minimum recommended version
-//    for the CLI.
-// 2. Show a warning asking the user to upgrade their CLI.
-//
-// Unfortunately, the VSCode extension is bundled with the semgrep CLI.
-// I don't think we should encourage users to upgrade their CLI
-// independently from the VSCode extension code. We should check the version
-// of the extension, not of the CLI. VSCode does this for us already.
-// TODO: Should we simply disable this version check?
-//
-// Note that we are still interested in collecting stats about the extension
-// version that users are running but this doesn't seem to be done here.
-//
-export async function checkCliVersion(
-  currentVersion: semver.SemVer,
-): Promise<void> {
-  const versionInfo = await getVersionInfo();
-  if (!versionInfo) {
-    return;
-  }
-  // Set context for the current version so we can gate vscode UI based on it
-  vscode.commands.executeCommand(
-    "setContext",
-    "semgrep.cli.minor",
-    currentVersion.minor,
-  );
-  vscode.commands.executeCommand(
-    "setContext",
-    "semgrep.cli.major",
-    currentVersion.major,
-  );
-  if (semver.compare(currentVersion, versionInfo.min) === -1) {
-    vscode.window.showErrorMessage(
-      `The Semgrep Extension requires a Semgrep CLI version ${versionInfo.min}, the current installed version is ${currentVersion}, please upgrade.`,
-    );
-  }
-  if (semver.compare(currentVersion, versionInfo.latest) === -1) {
-    vscode.window.showWarningMessage(
-      `Some features of the Semgrep Extension require a Semgrep CLI version ${versionInfo.latest}, but the current installed version is ${currentVersion}, some features may be disabled, please upgrade.`,
-    );
   }
 }
 


### PR DESCRIPTION
This asks a question about version check. If the question is legitimate but has no answers, let's leave it as a comment.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
