### PR TITLE
Simplify command names (generic AST -> AST)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
       },
       {
         "command": "semgrep.showAst",
-        "title": "Semgrep: Show Generic AST"
+        "title": "Semgrep: Show AST"
       },
       {
         "command": "semgrep.showAstNamed",
-        "title": "Semgrep: Show named Generic AST",
+        "title": "Semgrep: Show named AST",
         "when": "semgrep.cli.minor >= 36 || config.semgrep.ignoreCliVersion"
       },
       {


### PR DESCRIPTION
Unless we offer different kinds of ASTs, there's no need to refer to the "generic AST". It's just the AST.

Test plan: Ctrl+Shift+p -> check that the name of the commands refer to the "AST" rather than to the "Generic AST"

I don't think we should create a changelog entry for this.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
