### PR TITLE
Remove commands that only tell us that they only work from the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove unusable commands for search and search+replace from the list
+  of commands. Use the sidebar.
 - Avoid extension activation error due to a failure of `osemgrep-pro --version`.
 
 ## v1.9.0 - 2024-08-28

--- a/package.json
+++ b/package.json
@@ -69,12 +69,6 @@
         "when": "semgrep.cli.minor >= 36 || config.semgrep.ignoreCliVersion"
       },
       {
-        "command": "semgrep.search",
-        "title": "Semgrep: Search by pattern",
-        "icon": "$(search-view-icon)",
-        "when": "semgrep.cli.minor >= 70 || config.semgrep.ignoreCliVersion"
-      },
-      {
         "command": "semgrep.search.clear",
         "title": "Semgrep Search: Clear",
         "icon": "$(search-remove)",
@@ -84,12 +78,6 @@
         "command": "semgrep.search.exportRule",
         "title": "Semgrep Search: Export Rule",
         "icon": "$(search-remove)",
-        "when": "semgrep.cli.minor >= 70 || config.semgrep.ignoreCliVersion"
-      },
-      {
-        "command": "semgrep.search.replace",
-        "title": "Semgrep Search: Semantic Replace",
-        "icon": "$(replace)",
         "when": "semgrep.cli.minor >= 70 || config.semgrep.ignoreCliVersion"
       },
       {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -223,8 +223,10 @@ async function lspOptions(
 
   let serverOptions;
   // if we're not using JS, we can use the native binary
+  env.logger.log("obtain LSP server options (native)");
   serverOptions = await serverOptionsCli(env);
   if (!serverOptions || env.config.get("useJS")) {
+    env.logger.log("obtain LSP server options (JS)");
     serverOptions = serverOptionsJs(env);
   }
 


### PR DESCRIPTION
Is there a way to invoke these commands from the sidebar without an error? If so, this should be explained to the user.

This PR removes the pattern search/replace commands since there doesn't seem to be a way to make them work.

test plan: run the extension, check that Ctrl+Shift+p doesn't list the commands to search and replace.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
