### PR TITLE
Make the "show AST" commands fail silently if the current window is not a text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid extension activation error due to a failure of `osemgrep-pro --version`.
+- Avoid error when requesting the AST from a window that's not a text editor.
+
 
 ## v1.9.0 - 2024-08-28
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,7 +14,7 @@ import {
 } from "./lspExtensions";
 import { handleSearch } from "./search";
 import { encodeUri } from "./showAstDocument";
-import { applyFixAndSave, replaceAll } from "./utils";
+import { applyFixAndSave, isRealFileEditor, replaceAll } from "./utils";
 import type { ViewResults } from "./webviews/types/results";
 
 /*****************************************************************************/
@@ -148,7 +148,7 @@ export function registerCommands(env: Environment): Disposable[] {
     /************/
 
     vscode.commands.registerCommand("semgrep.showAstNamed", async () => {
-      if (vscode.window.activeTextEditor == null) {
+      if (! isRealFileEditor(vscode.window.activeTextEditor)) {
         return;
       }
       if (env.client) {
@@ -161,7 +161,7 @@ export function registerCommands(env: Environment): Disposable[] {
       }
     }),
     vscode.commands.registerCommand("semgrep.showAst", async () => {
-      if (vscode.window.activeTextEditor == null) {
+      if (! isRealFileEditor(vscode.window.activeTextEditor)) {
         return;
       }
       if (env.client) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,3 +59,18 @@ export async function replaceAll(matches: ViewResults): Promise<void> {
   );
   await applyFixAndSave(edit);
 }
+
+// Check if the current window is an open file rather than something else
+export function isRealFileEditor(editor: vscode.TextEditor | undefined): boolean {
+  if (!editor) return false;
+
+  const doc = editor.document;
+
+  // Check that it is not untitled (unsaved new file)
+  if (doc.isUntitled) return false;
+
+  // Check that it has a file:// URI scheme
+  if (doc.uri.scheme !== 'file') return false;
+
+  return true;
+}


### PR DESCRIPTION
This only fixes the test that checks if we're in a proper editor window.

The error was silent and is still silent. I think it's fine this way.

test plan: open the output window (logs), invoke the command to show the AST, check that there's no error message containing an ocaml exception about a missing file with a weird name.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
