### PR TITLE
chore: add option for experimental new LS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To configure the Semgrep extension, open its **Extension Settings** page:
 The following experimental features should only be used upon recommendation by Semgrep:
 
 - **Semgrep > Ignore Cli Version**: Ignore the CLI Version and enable all extension features.
+- **Semgrep > Use experimental language server**: Use the new experimental language server
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "semgrep.useExperimentalLS": {
           "type": "boolean",
           "default": false,
-          "description": "Use the new experimental language server"
+          "description": "Use the new experimental language server (requires restart)"
         },
         "semgrep.scan.configuration": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
         "semgrep.scan.jobs": {
           "type": "integer",
           "default": 2,
-          "description": "Number of parallel jobs to run."
+          "description": "Number of parallel jobs to run. (does not apply to experimental language server)"
         },
         "semgrep.scan.maxMemory": {
           "type": "integer",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
           "default": false,
           "description": "Ignore CLI Version, and enable all extension features (Warning: this is mainly for extension development, and can break things if enabled!)"
         },
+        "semgrep.useExperimentalLS": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use the new experimental language server"
+        },
         "semgrep.scan.configuration": {
           "type": "array",
           "items": {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -105,6 +105,10 @@ function semgrepCmdLineOpts(env: Environment): string[] {
     cmdlineOpts.push(...["--debug"]);
   }
 
+  if (env.config.cfg.get("useExperimentalLS")) {
+    cmdlineOpts.push(...["--x-eio-ls"]);
+  }
+
   return cmdlineOpts;
 }
 


### PR DESCRIPTION
In https://github.com/semgrep/semgrep-proprietary/pull/4127, we added the ability to invoke either the legacy or pro language server, via cmdline. This PR adds a UI setting which will enable either LSP.

## Test plan:
I manually checked that the right command-line flag was included based off of this setting.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
