### PR TITLE
chore: specify num jobs doesnt work for experimental server

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
         "semgrep.scan.jobs": {
           "type": "integer",
           "default": 2,
-          "description": "Number of parallel jobs to run."
+          "description": "Number of parallel jobs to run. (does not apply to experimental language server)"
         },
         "semgrep.scan.maxMemory": {
           "type": "integer",


### PR DESCRIPTION
The new language server cannot fork in its children, so num jobs will not work for it.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
