### PR TITLE
chore: don't auto collect sensitive telemetry

### DIFF
--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -163,7 +163,17 @@ export function startTracing(
       [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: environment,
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
+      // Not exactly the same as the auto-collected OpenTelemetry
+      // resources, so don't rely on exact correctness.
+      // But, these are useful and good to collect.
+      ["arch"]: process.arch,
+      ["process.runtime.name"]: "node",
+      ["process.runtime.version"]: process.versions.node,
     }),
+    // Don't auto-detect resources, this picks up things like IP addresses
+    // and usernames, which we don't want to collect.
+    // Because it does collect some useful things, we manually add
+    // them back up above.
     autoDetectResources: false,
     instrumentations: [getNodeAutoInstrumentations()],
   });

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -164,6 +164,7 @@ export function startTracing(
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
     }),
+    autoDetectResources: false,
     instrumentations: [getNodeAutoInstrumentations()],
   });
 


### PR DESCRIPTION
We don't want to auto-collect things like IP addresses, user names, etc. This turns it off from being auto detected.

## How:
We stopped the auto-collected stuff, but also added back some useful information.

## Test plan:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/ad4e50aa-7648-49f3-b9de-472fdc0fd314" />


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
