### PR TITLE
feat: telemetry setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
           "default": false,
           "description": "Use the new experimental language server (requires restart)"
         },
+        "semgrep.metrics": {
+          "type": "boolean",
+          "default": true,
+          "description": "Send metrics to Semgrep to help improve our products and services. Telemetry data includes scan metrics, extension runtime version details, and other information as described here: https://semgrep.dev/docs/metrics#data-collected-as-metrics."
+        },
         "semgrep.scan.configuration": {
           "type": "array",
           "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,12 +93,14 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
   );
   vscode.commands.executeCommand("semgrep.loginStatus").then(async () => {
     vscode.commands.executeCommand("semgrep.loginNudge");
-await vscode.window.showInformationMessage(
-  `VS Code collects usage data and sends it to Semgrep to help improve our products and services. Telemetry data includes extension runtime version details, and other metrics normally collected by Semgrep, [as described here](https://semgrep.dev/docs/metrics#data-collected-as-metrics).
-  If you don't wish to send usage data to Semgrep, you can set the \`telemetry.telemetryLevel\` setting to \`off\`.`,
-);
     if (env.newInstall) {
       env.newInstall = false;
+
+      await vscode.window.showInformationMessage(
+        `VS Code collects usage data and sends it to Semgrep to help improve our products and services. Telemetry data includes extension runtime version details, and other metrics normally collected by Semgrep, [as described here](https://semgrep.dev/docs/metrics#data-collected-as-metrics).
+        If you don't wish to send usage data to Semgrep, you can set the \`telemetry.telemetryLevel\` setting to \`off\`.`,
+      );
+
       const selection = await vscode.window.showInformationMessage(
         "Semgrep Extension successfully installed. Would you like to try performing a full workspace scan (may take longer on bigger workspaces)?",
         "Scan Full Workspace",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
 
       await vscode.window.showInformationMessage(
         `VS Code collects usage data and sends it to Semgrep to help improve our products and services. Telemetry data includes extension runtime version details, and other metrics normally collected by Semgrep, [as described here](https://semgrep.dev/docs/metrics#data-collected-as-metrics).
-        If you don't wish to send usage data to Semgrep, you can set the \`telemetry.telemetryLevel\` setting to \`off\`.`,
+        If you don't wish to send usage data to Semgrep, you can unset the \`Semgrep: Metrics\` setting.`,
       );
 
       const selection = await vscode.window.showInformationMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,10 +93,14 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
   );
   vscode.commands.executeCommand("semgrep.loginStatus").then(async () => {
     vscode.commands.executeCommand("semgrep.loginNudge");
+await vscode.window.showInformationMessage(
+  `VS Code collects usage data and sends it to Semgrep to help improve our products and services. Telemetry data includes extension runtime version details, and other metrics normally collected by Semgrep, [as described here](https://semgrep.dev/docs/metrics#data-collected-as-metrics).
+  If you don't wish to send usage data to Semgrep, you can set the \`telemetry.telemetryLevel\` setting to \`off\`.`,
+);
     if (env.newInstall) {
       env.newInstall = false;
       const selection = await vscode.window.showInformationMessage(
-        "Semgrep Extension succesfully installed. Would you like to try performing a full workspace scan (may take longer on bigger workspaces)?",
+        "Semgrep Extension successfully installed. Would you like to try performing a full workspace scan (may take longer on bigger workspaces)?",
         "Scan Full Workspace",
         "Dismiss",
       );

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -212,11 +212,15 @@ async function start(env: Environment): Promise<void> {
   // Start the client. This will also launch the server
   env.logger.log("Starting language client...");
 
-  // We instrument the language client with tracing so we can get
-  // spans for the requests that it is making.
-  // Because we monkeypatch several methods that it contains, we
-  // must do this as soon as possible after it is created.
-  await setupLanguageClientTracing(env, c);
+  if (env.config.get("metrics")) {
+    // We instrument the language client with tracing so we can get
+    // spans for the requests that it is making.
+    // Because we monkeypatch several methods that it contains, we
+    // must do this as soon as possible after it is created.
+    await setupLanguageClientTracing(env, c);
+  } else {
+    env.logger.log("Metrics are disabled, not setting up tracing...");
+  }
 
   const notificationHandler: NotificationHandler0 = () => {
     env.logger.log("Rules loaded");

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -156,6 +156,8 @@ export function startTracing(
     url: endpoint,
   });
 
+  const hasMetrics: boolean | undefined = env.config.cfg.get("metrics");
+
   const sdk = new NodeSDK({
     traceExporter,
     resource: resourceFromAttributes({
@@ -163,6 +165,7 @@ export function startTracing(
       [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: environment,
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
+      ["client.metrics"]: hasMetrics,
       // Not exactly the same as the auto-collected OpenTelemetry
       // resources, so don't rely on exact correctness.
       // But, these are useful and good to collect.


### PR DESCRIPTION
This PR adds a setting which allows people to opt out of telemetry, as well as an informative message which displays on new install, detailing the metrics that we collect.

## Test plan:
<img width="503" alt="image" src="https://github.com/user-attachments/assets/61155c62-acca-467c-899a-c09b1cd62bd8" />

Also tested that metrics do not get reported when I turn the setting off.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
