### PR TITLE
fix: use official dev env

### DIFF
--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -139,6 +139,19 @@ export async function setupLanguageClientTracing(
   env.logger.log("Patched language server with tracing.");
 }
 
+function environmentToTraceEnvironment(environment: ExtensionEnvironment) : string {
+  switch (environment) {
+    case ExtensionEnvironment.Development:
+      return "dev";
+    case ExtensionEnvironment.Release:
+      return "prod";
+    case ExtensionEnvironment.Test:
+      return "local";
+    default:
+      return "unknown";
+  }
+}
+
 export function startTracing(
   env: Environment,
   environment: ExtensionEnvironment,
@@ -162,7 +175,7 @@ export function startTracing(
     traceExporter,
     resource: resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: "semgrep-vscode",
-      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: environment,
+      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: environmentToTraceEnvironment(environment),
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
       ["client.metrics"]: hasMetrics,

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -139,7 +139,9 @@ export async function setupLanguageClientTracing(
   env.logger.log("Patched language server with tracing.");
 }
 
-function environmentToTraceEnvironment(environment: ExtensionEnvironment) : string {
+function environmentToTraceEnvironment(
+  environment: ExtensionEnvironment,
+): string {
   switch (environment) {
     case ExtensionEnvironment.Development:
       return "dev";
@@ -175,7 +177,8 @@ export function startTracing(
     traceExporter,
     resource: resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: "semgrep-vscode",
-      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: environmentToTraceEnvironment(environment),
+      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]:
+        environmentToTraceEnvironment(environment),
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
       ["client.metrics"]: hasMetrics,

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -148,9 +148,9 @@ function environmentToTraceEnvironment(
     case ExtensionEnvironment.Release:
       return "prod";
     case ExtensionEnvironment.Test:
-      return "local";
+      return "dev";
     default:
-      return "unknown";
+      return "dev";
   }
 }
 


### PR DESCRIPTION
We were using `release` and stuff instead of `prod`, in the telemetry.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
