### PR TITLE
fix: prioritize bundled semgrep

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -49,7 +49,10 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
   // the proprietary binary in the extension. Additionally, any devs that are doing work
   // on `semgrep` will fall into this code path and possibly failure, if they have ever
   // built Semgrep locally.
-  if (!serverPath) {
+  // We need the check for the existence of the binary though, because someone
+  // might have a messed up situation, or you could be using the extension
+  // locally in a dev environment.
+  if (!serverPath && fs.existsSync(DIST_BINARY_PATH)) {
     serverPath = DIST_BINARY_PATH;
     // Read version from extension's shipped version file
     // This is hacky, we should instead exec the binary with --version like we did previously, but that is currently off by one release always

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -44,7 +44,25 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
     serverPath = env.config.path;
   }
 
-  // check if the path exists
+  // Next, try to use the packaged Semgrep binary.
+  // We prefer this to the locally existent semgrep, because we are guaranteed to have
+  // the proprietary binary in the extension. Additionally, any devs that are doing work
+  // on `semgrep` will fall into this code path and possibly failure, if they have ever
+  // built Semgrep locally.
+  if (!serverPath) {
+    serverPath = DIST_BINARY_PATH;
+    // Read version from extension's shipped version file
+    // This is hacky, we should instead exec the binary with --version like we did previously, but that is currently off by one release always
+    const version = fs
+      .readFileSync(VERSION_PATH)
+      .toString()
+      .trim()
+      .replace("release-", "");
+    env.semgrepVersion = version;
+    await env.reloadConfig();
+  }
+
+  // But if that fails, let's try the `semgrep` on the PATH.
   if (!serverPath || !fs.existsSync(serverPath)) {
     // try checking if its a binary in the PATH
     serverPath = which.sync("semgrep", { nothrow: true });
@@ -59,21 +77,8 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
     await env.reloadConfig();
   }
 
-  if (!serverPath) {
-    serverPath = DIST_BINARY_PATH;
-    // Read version from extension's shipped version file
-    // This is hacky, we should instead exec the binary with --version like we did previously, but that is currently off by one release always
-    const version = fs
-      .readFileSync(VERSION_PATH)
-      .toString()
-      .trim()
-      .replace("release-", "");
-    env.semgrepVersion = version;
-    await env.reloadConfig();
-  }
-
   // one last check to see if the binary exists
-  if (fs.existsSync(serverPath)) {
+  if (serverPath && fs.existsSync(serverPath)) {
     return {
       command: serverPath,
     };

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -40,7 +40,7 @@ const execShell = (cmd: string, args: string[]) =>
 async function findSemgrep(env: Environment): Promise<Executable | null> {
   let serverPath;
   // First, check if the user has set the path to the Semgrep binary, use that always
-  if (env.config.path.length > 0) {
+  if (env.config.path.length > 0 && fs.existsSync(env.config.path)) {
     serverPath = env.config.path;
   }
 
@@ -66,7 +66,7 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
   }
 
   // But if that fails, let's try the `semgrep` on the PATH.
-  if (!serverPath || !fs.existsSync(serverPath)) {
+  if (!serverPath) {
     // try checking if its a binary in the PATH
     serverPath = which.sync("semgrep", { nothrow: true });
   }
@@ -82,6 +82,8 @@ async function findSemgrep(env: Environment): Promise<Executable | null> {
 
   // one last check to see if the binary exists
   if (serverPath && fs.existsSync(serverPath)) {
+    env.logger.log(`Found Semgrep binary at: ${serverPath}`);
+
     return {
       command: serverPath,
     };


### PR DESCRIPTION
This makes it so we prioritize the bundled Semgrep, as it is more likely to be correct with respect to the IDE.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
