### PR TITLE
chore: log from client on `messages` setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semgrep",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "semgrep",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.60.1",

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,7 +24,8 @@ export class Config {
   }
 
   get trace(): boolean {
-    return this.cfg.get<string>("trace.server") == "verbose";
+    const trace_setting = this.cfg.get<string>("trace.server");
+    return trace_setting == "verbose" || trace_setting == "messages";
   }
 
   get path(): string {


### PR DESCRIPTION
This PR makes it so the language client logs on the `messages` setting, whereas previously it didn't unless it was `verbose`.

The logs from the client are quite useful, but `verbose` is too verbose, it causes the language _server_ to print out extremely verbose output detailing each request sent. A nice middle ground is making it so `messages` displays language client logs and the less-verbose language server logs (which it already does).

## Test plan:
Verified that `env.logger.log` calls now appear if trace level is`messages`.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
