### PR TITLE
feat(telemetry): pass trace endpoint

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -21,6 +21,8 @@ function getExtensionDevEnv(mode: ExtensionMode): ExtensionEnvironment {
   if (process.env.SEMGREP_DEV_ENVIRONMENT) {
     const env = process.env.SEMGREP_DEV_ENVIRONMENT;
     switch (env) {
+      // The string is the same as the underlying representation of the
+      // `ExtensionEnvironment` type, but let's just keep the casing.
       case "semgrep-prod":
         return ExtensionEnvironment.Prod;
       case "semgrep-dev":

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:stream";
 import * as vscode from "vscode";
 import {
   type ExtensionContext,
+  ExtensionMode,
   type OutputChannel,
   type WorkspaceConfiguration,
   window,
@@ -14,6 +15,35 @@ import { SemgrepDocumentProvider } from "./showAstDocument";
 import { Logger } from "./utils";
 import type { SemgrepSearchWebviewProvider } from "./views/webview";
 import { NodeSDK } from "@opentelemetry/sdk-node";
+import { ExtensionEnvironment } from "./utilities/tracing";
+
+function getExtensionDevEnv(mode: ExtensionMode): ExtensionEnvironment {
+  if (process.env.SEMGREP_DEV_ENVIRONMENT) {
+    const env = process.env.SEMGREP_DEV_ENVIRONMENT;
+    switch (env) {
+      case "semgrep-prod":
+        return ExtensionEnvironment.Prod;
+      case "semgrep-dev":
+        return ExtensionEnvironment.Dev;
+      case "semgrep-local":
+        return ExtensionEnvironment.Local;
+    }
+    throw new Error(
+      `Unknown SEMGREP_DEV_ENVIRONMENT value: ${env}, need 'semgrep-local', 'semgrep-dev' or 'semgrep-prod'`,
+    );
+  }
+    // If there is no env variable, use the mode to determine the environment.
+    switch (mode) {
+      case ExtensionMode.Development:
+        return ExtensionEnvironment.Dev;
+      case ExtensionMode.Production:
+        return ExtensionEnvironment.Prod;
+      // Importantly, test mode is the dev environment still.
+      case ExtensionMode.Test:
+        return ExtensionEnvironment.Dev;
+    }
+}
+
 
 export class Config {
   get cfg(): WorkspaceConfiguration {
@@ -57,6 +87,14 @@ export class Environment {
   // Set in the `startTracing` function in `tracing.ts`.
   public sdk: NodeSDK | null = null;
 
+  // `extensionDevEnvironment` is the environment that the extension wants to
+  // report its traces in. This can be configured by setting the
+  // SEMGREP_DEV_ENVIRONMENT environment variable to one of
+  // 'semgrep-local', 'semgrep-dev', or 'semgrep-prod', or falls back to being
+  // derived from the extension mode, which is the mode of the VS Code extension
+  // itself.
+  public extensionDevEnvironment: ExtensionEnvironment = ExtensionEnvironment.Prod;
+
   private _client: LanguageClient | null = null;
   private _provider: SemgrepSearchWebviewProvider | null = null;
   private constructor(
@@ -67,7 +105,9 @@ export class Environment {
     public config: Config,
     // rulesRefreshedEmitter is used to notify if rules are refreshed, i.e. after startup, a login, or a manual refresh
     private rulesRefreshedEmitter: EventEmitter = new EventEmitter(),
-  ) {}
+  ) {
+    this.extensionDevEnvironment = getExtensionDevEnv(context.extensionMode);
+  }
 
   loginEvent?: vscode.EventEmitter<void> = undefined;
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,18 +34,17 @@ function getExtensionDevEnv(mode: ExtensionMode): ExtensionEnvironment {
       `Unknown SEMGREP_DEV_ENVIRONMENT value: ${env}, need 'semgrep-local', 'semgrep-dev' or 'semgrep-prod'`,
     );
   }
-    // If there is no env variable, use the mode to determine the environment.
-    switch (mode) {
-      case ExtensionMode.Development:
-        return ExtensionEnvironment.Dev;
-      case ExtensionMode.Production:
-        return ExtensionEnvironment.Prod;
-      // Importantly, test mode is the dev environment still.
-      case ExtensionMode.Test:
-        return ExtensionEnvironment.Dev;
-    }
+  // If there is no env variable, use the mode to determine the environment.
+  switch (mode) {
+    case ExtensionMode.Development:
+      return ExtensionEnvironment.Dev;
+    case ExtensionMode.Production:
+      return ExtensionEnvironment.Prod;
+    // Importantly, test mode is the dev environment still.
+    case ExtensionMode.Test:
+      return ExtensionEnvironment.Dev;
+  }
 }
-
 
 export class Config {
   get cfg(): WorkspaceConfiguration {
@@ -95,7 +94,8 @@ export class Environment {
   // 'semgrep-local', 'semgrep-dev', or 'semgrep-prod', or falls back to being
   // derived from the extension mode, which is the mode of the VS Code extension
   // itself.
-  public extensionDevEnvironment: ExtensionEnvironment = ExtensionEnvironment.Prod;
+  public extensionDevEnvironment: ExtensionEnvironment =
+    ExtensionEnvironment.Prod;
 
   private _client: LanguageClient | null = null;
   private _provider: SemgrepSearchWebviewProvider | null = null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export async function activate(
   const env: Environment = await createOrUpdateEnvironment(context);
   initTelemetry(env);
 
-  await withSpan("activateLsp", {}, async () => activateLsp(env));
+  await withSpan("activateLsp", {}, () => activateLsp(env));
   await afterClientStart(context, env);
   return env;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 
 import {
-  ExtensionMode,
   type ConfigurationChangeEvent,
   type ExtensionContext,
 } from "vscode";
@@ -12,7 +11,7 @@ import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { SemgrepDocumentProvider } from "./showAstDocument";
 import { createStatusBar } from "./statusBar";
 import { initTelemetry, stopTelemetry } from "./telemetry/telemetry";
-import { ExtensionEnvironment, withSpan } from "./utilities/tracing";
+import { withSpan } from "./utilities/tracing";
 import { SemgrepPolicyViewProvider } from "./views/policy";
 import { SemgrepHelpProvider } from "./views/support";
 import { SemgrepSearchWebviewProvider } from "./views/webview";
@@ -113,27 +112,14 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
   });
 }
 
-function getExtensionMode(context: ExtensionContext): ExtensionEnvironment {
-  if (process.env.SEMGREP_DEV_ENVIRONMENT) {
-    return process.env.SEMGREP_DEV_ENVIRONMENT as ExtensionEnvironment;
-  } else {
-    if (context.extensionMode === ExtensionMode.Production) {
-      return ExtensionEnvironment.Release;
-    } else if (context.extensionMode === ExtensionMode.Development) {
-      return ExtensionEnvironment.Development;
-    } else {
-      return ExtensionEnvironment.Test;
-    }
-  }
-}
-
 export async function activate(
   context: ExtensionContext,
 ): Promise<Environment | undefined> {
   const env: Environment = await createOrUpdateEnvironment(context);
-  const extensionEnvironment: ExtensionEnvironment = getExtensionMode(context);
-  initTelemetry(extensionEnvironment, env);
-  await withSpan("activateLsp", {}, () => activateLsp(env));
+  initTelemetry(env);
+
+  await
+    withSpan("activateLsp", {}, async () => activateLsp(env));
   await afterClientStart(context, env);
   return env;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode";
 
-import {
-  type ConfigurationChangeEvent,
-  type ExtensionContext,
-} from "vscode";
+import { type ConfigurationChangeEvent, type ExtensionContext } from "vscode";
 import { registerCommands } from "./commands";
 import { VSCODE_CONFIG_KEY } from "./constants";
 import { Environment } from "./env";
@@ -118,8 +115,7 @@ export async function activate(
   const env: Environment = await createOrUpdateEnvironment(context);
   initTelemetry(env);
 
-  await
-    withSpan("activateLsp", {}, async () => activateLsp(env));
+  await withSpan("activateLsp", {}, async () => activateLsp(env));
   await afterClientStart(context, env);
   return env;
 }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -25,7 +25,7 @@ import {
 } from "./constants";
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
-import { extensionEnvToCmdlineSemgrepTraceEndpoint, setupLanguageClientTracing} from "./utilities/tracing";
+import { setupLanguageClientTracing} from "./utilities/tracing";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -115,10 +115,9 @@ function semgrepCmdLineOpts(env: Environment): string[] {
   }
 
   if (vscode.env.isTelemetryEnabled) {
-    const cmdlineTraceEndpoint = extensionEnvToCmdlineSemgrepTraceEndpoint(
-      env.extensionDevEnvironment,
-    );
-    cmdlineOpts.push(...["--trace", "--trace-endpoint", cmdlineTraceEndpoint])
+    // Because we represent `extensionDevEnvironment` the same as the string that is
+    // given to `--trace-endpoint`, we can just use it directly here.
+    cmdlineOpts.push(...["--trace", "--trace-endpoint", env.extensionDevEnvironment]);
   }
 
   return cmdlineOpts;

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -114,13 +114,13 @@ function semgrepCmdLineOpts(env: Environment): string[] {
     cmdlineOpts.push(...["--x-eio-ls"]);
   }
 
-  if (vscode.env.isTelemetryEnabled) {
-    // Because we represent `extensionDevEnvironment` the same as the string that is
-    // given to `--trace-endpoint`, we can just use it directly here.
-    cmdlineOpts.push(
-      ...["--trace", "--trace-endpoint", env.extensionDevEnvironment],
-    );
-  }
+  // if (vscode.env.isTelemetryEnabled) {
+  //   // Because we represent `extensionDevEnvironment` the same as the string that is
+  //   // given to `--trace-endpoint`, we can just use it directly here.
+  //   cmdlineOpts.push(
+  //     ...["--trace", "--trace-endpoint", env.extensionDevEnvironment],
+  //   );
+  // }
 
   return cmdlineOpts;
 }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -25,7 +25,7 @@ import {
 } from "./constants";
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
-import { setupLanguageClientTracing } from "./utilities/tracing";
+import { extensionEnvToCmdlineSemgrepTraceEndpoint, setupLanguageClientTracing} from "./utilities/tracing";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -112,6 +112,13 @@ function semgrepCmdLineOpts(env: Environment): string[] {
 
   if (env.config.cfg.get("useExperimentalLS")) {
     cmdlineOpts.push(...["--x-eio-ls"]);
+  }
+
+  if (vscode.env.isTelemetryEnabled) {
+    const cmdlineTraceEndpoint = extensionEnvToCmdlineSemgrepTraceEndpoint(
+      env.extensionDevEnvironment,
+    );
+    cmdlineOpts.push(...["--trace", "--trace-endpoint", cmdlineTraceEndpoint])
   }
 
   return cmdlineOpts;

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -25,7 +25,7 @@ import {
 } from "./constants";
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
-import { setupLanguageClientTracing} from "./utilities/tracing";
+import { setupLanguageClientTracing } from "./utilities/tracing";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -117,7 +117,9 @@ function semgrepCmdLineOpts(env: Environment): string[] {
   if (vscode.env.isTelemetryEnabled) {
     // Because we represent `extensionDevEnvironment` the same as the string that is
     // given to `--trace-endpoint`, we can just use it directly here.
-    cmdlineOpts.push(...["--trace", "--trace-endpoint", env.extensionDevEnvironment]);
+    cmdlineOpts.push(
+      ...["--trace", "--trace-endpoint", env.extensionDevEnvironment],
+    );
   }
 
   return cmdlineOpts;

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -114,13 +114,13 @@ function semgrepCmdLineOpts(env: Environment): string[] {
     cmdlineOpts.push(...["--x-eio-ls"]);
   }
 
-  // if (vscode.env.isTelemetryEnabled) {
-  //   // Because we represent `extensionDevEnvironment` the same as the string that is
-  //   // given to `--trace-endpoint`, we can just use it directly here.
-  //   cmdlineOpts.push(
-  //     ...["--trace", "--trace-endpoint", env.extensionDevEnvironment],
-  //   );
-  // }
+  if (vscode.env.isTelemetryEnabled) {
+    // Because we represent `extensionDevEnvironment` the same as the string that is
+    // given to `--trace-endpoint`, we can just use it directly here.
+    cmdlineOpts.push(
+      ...["--trace", "--trace-endpoint", env.extensionDevEnvironment],
+    );
+  }
 
   return cmdlineOpts;
 }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -2,9 +2,7 @@ import * as vscode from "vscode";
 import type { Environment } from "../env";
 import { startTracing, stopTracing } from "../utilities/tracing";
 
-export function initTelemetry(
-  env: Environment,
-): void {
+export function initTelemetry(env: Environment): void {
   if (env.hasTracingEnabled) {
     startTracing(env);
   }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,17 +1,15 @@
 import * as vscode from "vscode";
 import type { Environment } from "../env";
 import {
-  ExtensionEnvironment,
   startTracing,
   stopTracing,
 } from "../utilities/tracing";
 
 export function initTelemetry(
-  extensionEnvironment: ExtensionEnvironment,
   env: Environment,
 ): void {
   if (env.hasTracingEnabled) {
-    startTracing(env, extensionEnvironment);
+    startTracing(env);
   }
 }
 

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode";
 import type { Environment } from "../env";
-import {
-  startTracing,
-  stopTracing,
-} from "../utilities/tracing";
+import { startTracing, stopTracing } from "../utilities/tracing";
 
 export function initTelemetry(
   env: Environment,

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -51,11 +51,6 @@ const default_local_endpoint = "http://localhost:4318/v1/traces";
 
 const tracer = trace.getTracer("semgrep-vscode");
 
-// Some globals which let us maintain a "top-level span" so we can
-// nest our spans underneath a common parent.
-// See the large comment near `RootContextManager` for more details.
-export const topLevelSpan: api.Span | null = null;
-
 /******************************************************************************/
 /* Helpers */
 /******************************************************************************/

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -1,4 +1,4 @@
-import { api, NodeSDK } from "@opentelemetry/sdk-node";
+import { NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { Environment } from "../env";

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -35,9 +35,9 @@ import {
 /******************************************************************************/
 
 export enum ExtensionEnvironment {
-  Prod = "prod",
-  Dev = "dev",
-  Local = "local",
+  Prod = "semgrep-prod",
+  Dev = "semgrep-dev",
+  Local = "semgrep-local",
 }
 
 /******************************************************************************/
@@ -72,18 +72,6 @@ function extensionEnvToTraceEnvironment(
       return "local";
     default:
       return "dev";
-  }
-}
-
-export function extensionEnvToCmdlineSemgrepTraceEndpoint(
-  extensionEnv: ExtensionEnvironment) : string {
-  switch (extensionEnv) {
-    case ExtensionEnvironment.Dev:
-      return "semgrep-dev";
-    case ExtensionEnvironment.Prod:
-      return "semgrep-prod";
-    case ExtensionEnvironment.Local:
-      return "semgrep-local";
   }
 }
 
@@ -173,21 +161,6 @@ export async function setupLanguageClientTracing(
   };
 
   env.logger.log("Patched language server with tracing.");
-}
-
-function environmentToTraceEnvironment(
-  environment: ExtensionEnvironment,
-): string {
-  switch (environment) {
-    case ExtensionEnvironment.Development:
-      return "dev";
-    case ExtensionEnvironment.Release:
-      return "prod";
-    case ExtensionEnvironment.Test:
-      return "dev";
-    default:
-      return "dev";
-  }
 }
 
 export function startTracing(

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -1,4 +1,4 @@
-import { NodeSDK } from "@opentelemetry/sdk-node";
+import { api, NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { Environment } from "../env";
@@ -35,9 +35,9 @@ import {
 /******************************************************************************/
 
 export enum ExtensionEnvironment {
-  Release = "release",
-  Development = "development",
-  Test = "test",
+  Prod = "prod",
+  Dev = "dev",
+  Local = "local",
 }
 
 /******************************************************************************/
@@ -50,6 +50,42 @@ const default_dev_endpoint = "https://telemetry.dev2.semgrep.dev/v1/traces";
 const default_local_endpoint = "http://localhost:4318/v1/traces";
 
 const tracer = trace.getTracer("semgrep-vscode");
+
+// Some globals which let us maintain a "top-level span" so we can
+// nest our spans underneath a common parent.
+// See the large comment near `RootContextManager` for more details.
+export const topLevelSpan : api.Span | null = null;
+
+/******************************************************************************/
+/* Helpers */
+/******************************************************************************/
+
+function extensionEnvToTraceEnvironment(
+  extensionEnv: ExtensionEnvironment,
+): string {
+  switch (extensionEnv) {
+    case ExtensionEnvironment.Dev:
+      return "dev";
+    case ExtensionEnvironment.Prod:
+      return "prod";
+    case ExtensionEnvironment.Local:
+      return "local";
+    default:
+      return "dev";
+  }
+}
+
+export function extensionEnvToCmdlineSemgrepTraceEndpoint(
+  extensionEnv: ExtensionEnvironment) : string {
+  switch (extensionEnv) {
+    case ExtensionEnvironment.Dev:
+      return "semgrep-dev";
+    case ExtensionEnvironment.Prod:
+      return "semgrep-prod";
+    case ExtensionEnvironment.Local:
+      return "semgrep-local";
+  }
+}
 
 /******************************************************************************/
 /* Setup */
@@ -156,12 +192,13 @@ function environmentToTraceEnvironment(
 
 export function startTracing(
   env: Environment,
-  environment: ExtensionEnvironment,
 ): void {
   let endpoint: string;
-  if (environment === ExtensionEnvironment.Development) {
+
+  // Decide the endpoint based on the environment.
+  if (env.extensionDevEnvironment === ExtensionEnvironment.Dev) {
     endpoint = default_dev_endpoint;
-  } else if (environment === ExtensionEnvironment.Release) {
+  } else if (env.extensionDevEnvironment === ExtensionEnvironment.Prod) {
     endpoint = default_trace_endpoint;
   } else {
     endpoint = default_local_endpoint;
@@ -178,7 +215,7 @@ export function startTracing(
     resource: resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: "semgrep-vscode",
       [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]:
-        environmentToTraceEnvironment(environment),
+        extensionEnvToTraceEnvironment(env.extensionDevEnvironment),
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
       ["client.metrics"]: hasMetrics,

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -54,7 +54,7 @@ const tracer = trace.getTracer("semgrep-vscode");
 // Some globals which let us maintain a "top-level span" so we can
 // nest our spans underneath a common parent.
 // See the large comment near `RootContextManager` for more details.
-export const topLevelSpan : api.Span | null = null;
+export const topLevelSpan: api.Span | null = null;
 
 /******************************************************************************/
 /* Helpers */
@@ -163,9 +163,7 @@ export async function setupLanguageClientTracing(
   env.logger.log("Patched language server with tracing.");
 }
 
-export function startTracing(
-  env: Environment,
-): void {
+export function startTracing(env: Environment): void {
   let endpoint: string;
 
   // Decide the endpoint based on the environment.
@@ -187,8 +185,9 @@ export function startTracing(
     traceExporter,
     resource: resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: "semgrep-vscode",
-      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]:
-        extensionEnvToTraceEnvironment(env.extensionDevEnvironment),
+      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: extensionEnvToTraceEnvironment(
+        env.extensionDevEnvironment,
+      ),
       ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
       ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
       ["client.metrics"]: hasMetrics,


### PR DESCRIPTION
## What:
This PR makes it so you can specify, via `SEMGREP_DEV_ENVIRONMENT`, either `semgrep-local`, `semgrep-dev`, or `semgrep-prod`, which will cause traces to be set based off of that assumption, as well as passing it down to `semgrep lsp` via `--trace-endpoint`.

## Why:
This lets us synchronize doing tracing in both the language client and the language server.

## How:
I just kept some ambient state in the `Environment`.

Notably, we default back to the extension mode (as given by VS Code) if the env var is not configured.

## Test plan:
TBA

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
