### PR TITLE
chore: show deployment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The Policy menu now shows your deployment's name (if logged in)
+
 ## 1.12.2 - 2025-07-08
 
 ### Fixed

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -66,25 +66,25 @@ export function registerCommands(env: Environment): Disposable[] {
         vscode.env.openExternal(vscode.Uri.parse(result.url));
         const status = await env.client?.sendRequest(loginFinish, result);
         if (status) {
-          env.loggedIn = status.loggedIn;
+          env.deploymentName = status.deploymentName;
         }
       }
     }),
 
     vscode.commands.registerCommand("semgrep.logout", async () => {
       await env.client?.sendNotification(logout);
-      env.loggedIn = false;
+      env.deploymentName = null;
     }),
 
     vscode.commands.registerCommand("semgrep.loginStatus", async () => {
       const result = await env.client?.sendRequest(loginStatus);
       if (result) {
-        env.loggedIn = result.loggedIn;
+        env.deploymentName = result.deploymentName;
       }
     }),
 
     vscode.commands.registerCommand("semgrep.loginNudge", async () => {
-      if (!env.loggedIn && env.showNudges) {
+      if (!env.deploymentName && env.showNudges) {
         const resp = await vscode.window.showInformationMessage(
           "Sign in to use your team's shared Semgrep rule configuration",
           "Sign in",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -64,27 +64,27 @@ export function registerCommands(env: Environment): Disposable[] {
       const result = await env.client?.sendRequest(loginStart);
       if (result) {
         vscode.env.openExternal(vscode.Uri.parse(result.url));
-        const status = await env.client?.sendRequest(loginFinish, result);
-        if (status) {
-          env.deploymentName = status.deploymentName;
+        const info = await env.client?.sendRequest(loginFinish, result);
+        if (info) {
+          env.deploymentInfo = info;
         }
       }
     }),
 
     vscode.commands.registerCommand("semgrep.logout", async () => {
       await env.client?.sendNotification(logout);
-      env.deploymentName = null;
+      env.deploymentInfo = null;
     }),
 
     vscode.commands.registerCommand("semgrep.loginStatus", async () => {
       const result = await env.client?.sendRequest(loginStatus);
-      if (result) {
-        env.deploymentName = result.deploymentName;
+      if (result !== undefined) {
+        env.deploymentInfo = result;
       }
     }),
 
     vscode.commands.registerCommand("semgrep.loginNudge", async () => {
-      if (!env.deploymentName && env.showNudges) {
+      if (!env.deploymentInfo && env.showNudges) {
         const resp = await vscode.window.showInformationMessage(
           "Sign in to use your team's shared Semgrep rule configuration",
           "Sign in",

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,6 +40,12 @@ export class Config {
   }
 }
 
+export interface DeploymentInfo {
+  deploymentName: string;
+  deploymentId: number;
+  authToken: string;
+}
+
 export class Environment {
   public semgrepVersion: string | undefined;
 
@@ -71,11 +77,11 @@ export class Environment {
 
   loginEvent?: vscode.EventEmitter<void> = undefined;
 
-  get deploymentName(): string | null {
-    return this.context.globalState.get("deploymentName", null);
+  get deploymentInfo(): DeploymentInfo | null {
+    return this.context.globalState.get("deploymentInfo", null);
   }
 
-  set deploymentName(val: string | null) {
+  set deploymentInfo(val: DeploymentInfo | null) {
     vscode.commands.executeCommand(
       "setContext",
       "semgrep.loggedIn",
@@ -84,7 +90,7 @@ export class Environment {
     if (this.loginEvent) {
       this.loginEvent.fire();
     }
-    this.context.globalState.update("deploymentName", val);
+    this.context.globalState.update("deploymentInfo", val);
   }
 
   get showNudges(): boolean {

--- a/src/env.ts
+++ b/src/env.ts
@@ -71,16 +71,20 @@ export class Environment {
 
   loginEvent?: vscode.EventEmitter<void> = undefined;
 
-  get loggedIn(): boolean {
-    return this.context.globalState.get("loggedIn", false);
+  get deploymentName(): string | null {
+    return this.context.globalState.get("deploymentName", null);
   }
 
-  set loggedIn(val: boolean) {
-    vscode.commands.executeCommand("setContext", "semgrep.loggedIn", val);
+  set deploymentName(val: string | null) {
+    vscode.commands.executeCommand(
+      "setContext",
+      "semgrep.loggedIn",
+      val !== null,
+    );
     if (this.loginEvent) {
       this.loginEvent.fire();
     }
-    this.context.globalState.update("loggedIn", val);
+    this.context.globalState.update("deploymentName", val);
   }
 
   get showNudges(): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
 } from "vscode";
 import { registerCommands } from "./commands";
 import { VSCODE_CONFIG_KEY } from "./constants";
-import { Environment } from "./env";
+import { DeploymentInfo, Environment } from "./env";
 import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { SemgrepDocumentProvider } from "./showAstDocument";
 import { createStatusBar } from "./statusBar";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,6 +127,8 @@ function getExtensionMode(context: ExtensionContext): ExtensionEnvironment {
   }
 }
 
+// Automatically invoked by VS Code's extension API
+// https://code.visualstudio.com/api/get-started/extension-anatomy#extension-entry-file
 export async function activate(
   context: ExtensionContext,
 ): Promise<Environment | undefined> {

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -1,5 +1,6 @@
 import * as lc from "vscode-languageclient";
 import type { SearchResult } from "./search";
+import { DeploymentInfo } from "./env";
 
 // https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/lsp_ext.ts
 
@@ -23,10 +24,6 @@ export const scanWorkspace = new lc.NotificationType<ScanWorkspaceParams>(
 export interface LoginStartResponse {
   url: string;
   sessionId: string;
-}
-
-export interface LoginStatusResponse {
-  deploymentName: string | null;
 }
 
 // These are the parameters sent from the webview to the extnesion, which
@@ -55,13 +52,13 @@ export interface LspErrorParams {
   stack: string;
 }
 
-export const loginStart = new lc.RequestType0<LoginStartResponse | null, void>(
+export const loginStart = new lc.RequestType0<LoginStartResponse, void>(
   "semgrep/loginStart",
 );
 
 export const loginFinish = new lc.RequestType<
   LoginStartResponse,
-  LoginStatusResponse,
+  DeploymentInfo | null,
   void
 >("semgrep/loginFinish");
 
@@ -77,10 +74,9 @@ export const workspaceRules = new lc.RequestType0<any[], void>(
   "semgrep/workspaceRules",
 );
 
-export const loginStatus = new lc.RequestType0<
-  LoginStatusResponse | null,
-  void
->("semgrep/loginStatus");
+export const loginStatus = new lc.RequestType0<DeploymentInfo | null, void>(
+  "semgrep/loginStatus",
+);
 
 export const search = new lc.RequestType<LspSearchParams, SearchResults, void>(
   "semgrep/search",

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -26,7 +26,7 @@ export interface LoginStartResponse {
 }
 
 export interface LoginStatusResponse {
-  loggedIn: boolean;
+  deploymentName: string | null;
 }
 
 // These are the parameters sent from the webview to the extnesion, which

--- a/src/views/policy.ts
+++ b/src/views/policy.ts
@@ -34,9 +34,9 @@ export class SemgrepPolicyViewProvider
       const items: PolicyItem[] = [];
 
       // Show org policy if logged in
-      if (this.env.loggedIn) {
+      if (this.env.deploymentName) {
         const loginStatus = new PolicyItem(
-          "Using your organization's policy",
+          `Using ${this.env.deploymentName}'s policy`,
           vscode.TreeItemCollapsibleState.None,
         );
         loginStatus.iconPath = new vscode.ThemeIcon("cloud-download");

--- a/src/views/policy.ts
+++ b/src/views/policy.ts
@@ -36,7 +36,7 @@ export class SemgrepPolicyViewProvider
       // Show org policy if logged in
       if (this.env.deploymentName) {
         const loginStatus = new PolicyItem(
-          `Using ${this.env.deploymentName}'s policy`,
+          `Using deployment (${this.env.deploymentName})'s policy`,
           vscode.TreeItemCollapsibleState.None,
         );
         loginStatus.iconPath = new vscode.ThemeIcon("cloud-download");

--- a/src/views/policy.ts
+++ b/src/views/policy.ts
@@ -34,9 +34,9 @@ export class SemgrepPolicyViewProvider
       const items: PolicyItem[] = [];
 
       // Show org policy if logged in
-      if (this.env.deploymentName) {
+      if (this.env.deploymentInfo) {
         const loginStatus = new PolicyItem(
-          `Using deployment (${this.env.deploymentName})'s policy`,
+          `Using deployment (${this.env.deploymentInfo.deploymentName})'s policy`,
           vscode.TreeItemCollapsibleState.None,
         );
         loginStatus.iconPath = new vscode.ThemeIcon("cloud-download");


### PR DESCRIPTION
This PR makes it so you can see your organization's deployment name.

<img width="351" height="167" alt="image" src="https://github.com/user-attachments/assets/8a8d9e9a-4f2d-4ff9-855a-a46eadae77fc" />


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
