### PR TITLE
fix(metrics): use both vscode and our settings

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -98,6 +98,12 @@ export class Environment {
     this.context.globalState.update("newInstall", val);
   }
 
+  get hasTracingEnabled(): boolean {
+    return (
+      vscode.env.isTelemetryEnabled && (this.config.cfg.get("metrics") ?? false)
+    );
+  }
+
   set client(client: LanguageClient | null) {
     this._client = client;
   }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -158,7 +158,7 @@ async function lspOptions(
     sessionId: vscode.env.sessionId,
     extensionVersion: env.context.extension.packageJSON.version,
     extensionType: "vscode",
-    enabled: env.config.cfg.get("metrics") ?? false,
+    enabled: vscode.env.isTelemetryEnabled && env.hasTracingEnabled,
   };
   const initializationOptions = {
     ...env.config.cfg,
@@ -222,7 +222,7 @@ async function start(env: Environment): Promise<void> {
   // Start the client. This will also launch the server
   env.logger.log("Starting language client...");
 
-  if (env.config.get("metrics")) {
+  if (env.hasTracingEnabled) {
     // We instrument the language client with tracing so we can get
     // spans for the requests that it is making.
     // Because we monkeypatch several methods that it contains, we

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -158,7 +158,7 @@ async function lspOptions(
     sessionId: vscode.env.sessionId,
     extensionVersion: env.context.extension.packageJSON.version,
     extensionType: "vscode",
-    enabled: vscode.env.isTelemetryEnabled,
+    enabled: env.config.cfg.get("metrics") ?? false,
   };
   const initializationOptions = {
     ...env.config.cfg,

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -10,10 +10,9 @@ export function initTelemetry(
   extensionEnvironment: ExtensionEnvironment,
   env: Environment,
 ): void {
-  if (!vscode.env.isTelemetryEnabled) {
-    return;
+  if (env.config.cfg.get("metrics")) {
+    startTracing(env, extensionEnvironment);
   }
-  startTracing(env, extensionEnvironment);
 }
 
 export async function stopTelemetry(env: Environment): Promise<void> {

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -10,7 +10,7 @@ export function initTelemetry(
   extensionEnvironment: ExtensionEnvironment,
   env: Environment,
 ): void {
-  if (env.config.cfg.get("metrics")) {
+  if (env.hasTracingEnabled) {
     startTracing(env, extensionEnvironment);
   }
 }


### PR DESCRIPTION
We were relying on this `vscode.isTelemetryEnabled` field to determine if telemetry should be sent, without checking our own `semgrep.metrics` field. We should only send metrics if both are enabled, so that people can still disable metrics either way.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
