### PR TITLE
fix(metrics): send cursor metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug preventing OpenTelemetry traces from being sent from Cursor users
+
 ## 1.12.2 - 2025-07-08
 
 ### Fixed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,9 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
 export async function activate(
   context: ExtensionContext,
 ): Promise<Environment | undefined> {
+  // We want to deregister any existing OpenTelemetry global state
+  // as soon as we can, when the language server is started.
+  // See the description of this function for more.
   deregisterExistingOtel();
 
   const env: Environment = await createOrUpdateEnvironment(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { SemgrepDocumentProvider } from "./showAstDocument";
 import { createStatusBar } from "./statusBar";
 import { initTelemetry, stopTelemetry } from "./telemetry/telemetry";
-import { withSpan } from "./utilities/tracing";
+import { deregisterExistingOtel, withSpan } from "./utilities/tracing";
 import { SemgrepPolicyViewProvider } from "./views/policy";
 import { SemgrepHelpProvider } from "./views/support";
 import { SemgrepSearchWebviewProvider } from "./views/webview";
@@ -112,6 +112,8 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
 export async function activate(
   context: ExtensionContext,
 ): Promise<Environment | undefined> {
+  deregisterExistingOtel();
+
   const env: Environment = await createOrUpdateEnvironment(context);
   initTelemetry(env);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,7 @@ import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { SemgrepDocumentProvider } from "./showAstDocument";
 import { createStatusBar } from "./statusBar";
 import { initTelemetry, stopTelemetry } from "./telemetry/telemetry";
-import {
-  ExtensionEnvironment,
-  topLevelSpan,
-  withSpan,
-} from "./utilities/tracing";
+import { withSpan } from "./utilities/tracing";
 import { SemgrepPolicyViewProvider } from "./views/policy";
 import { SemgrepHelpProvider } from "./views/support";
 import { SemgrepSearchWebviewProvider } from "./views/webview";

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -84,6 +84,8 @@ export function deregisterExistingOtel(): void {
   const existing = globalThis_any[otelSymbol];
 
   if (existing) {
+    // Can't leave an `env.logger.log` because we did this super early on.
+    // nosem:
     console.log("Found existing OpenTelemetry instance, deregistering it");
     globalThis_any[otelSymbol] = undefined;
   }

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -20,8 +20,6 @@ import {
 } from "vscode-languageserver";
 import { StackContextManager } from "@opentelemetry/sdk-trace-web";
 
-deregisterExistingOtel();
-
 /******************************************************************************/
 /* Prelude */
 /******************************************************************************/
@@ -53,8 +51,6 @@ export enum ExtensionEnvironment {
 const default_trace_endpoint = "https://telemetry.semgrep.dev/v1/traces";
 const default_dev_endpoint = "https://telemetry.dev2.semgrep.dev/v1/traces";
 const default_local_endpoint = "http://localhost:4318/v1/traces";
-
-const tracer = trace.getTracer("semgrep-vscode");
 
 // Some globals which let us maintain a "top-level span" so we can
 // nest our spans underneath a common parent.
@@ -296,6 +292,8 @@ export function startTracing(env: Environment): void {
 
   env.sdk = sdk;
 
+  const tracer = trace.getTracer("semgrep-vscode");
+
   // Spawn the top-level span and context.
   // Important: We bind it here to activate the logic we added in `RootContextManager`.
   const span = tracer.startSpan("vscode-client");
@@ -332,6 +330,8 @@ export async function withSpan<T>(
   attributes: Record<string, any> = {},
   f: () => Promise<T>,
 ): Promise<T> {
+  const tracer = trace.getTracer("semgrep-vscode");
+
   const span = tracer.startSpan(name);
   span.setAttributes(attributes);
   try {

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -57,11 +57,29 @@ const default_local_endpoint = "http://localhost:4318/v1/traces";
 // See the large comment near `RootContextManager` for more details.
 export let topLevelSpan: api.Span | null = null;
 
+/**
+ * Deregisters any existing OpenTelemetry global state.
+ *
+ * This is important because we want to avoid any potential
+ * conflicts with other OpenTelemetry instances.
+ *
+ * For instance, Cursor ships with its own OpenTelemetry code and
+ * state, which will result in a conflict when we attempt to register
+ * our own (e.g. trace providers, context managers)
+ *
+ * This conflict ends up preventing our ability to sent OpenTelemetry
+ * spans whatsoever in Cursor.
+ */
 export function deregisterExistingOtel(): void {
   // Helps us avoid type errors.
   const globalThis_any = globalThis as any;
 
   // Warning! This will change if we upgrade to OpenTelemetry 2 or greater!
+  // Why is this the solution?
+  // https://github.com/open-telemetry/opentelemetry-js/blob/cb42f7d511a1b54d12d32a6a6bdc6266d5569c1b/api/src/internal/global-utils.ts#L39
+  // Registration of OpenTelemetry globals is done via indexing into the
+  // globalThis with a particular symbol, derived from `opentelemetry.js.api.${major}`
+  // So to deregister, we just need to set those fields of globalThis back to undefined.
   const otelSymbol = Symbol.for("opentelemetry.js.api.1");
   const existing = globalThis_any[otelSymbol];
 

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -1,4 +1,5 @@
 import { api, NodeSDK } from "@opentelemetry/sdk-node";
+
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
 import { Environment } from "../env";
@@ -18,6 +19,8 @@ import {
   type Connection,
 } from "vscode-languageserver";
 import { StackContextManager } from "@opentelemetry/sdk-trace-web";
+
+deregisterExistingOtel();
 
 /******************************************************************************/
 /* Prelude */
@@ -57,6 +60,20 @@ const tracer = trace.getTracer("semgrep-vscode");
 // nest our spans underneath a common parent.
 // See the large comment near `RootContextManager` for more details.
 export let topLevelSpan: api.Span | null = null;
+
+export function deregisterExistingOtel(): void {
+  // Helps us avoid type errors.
+  const globalThis_any = globalThis as any;
+
+  // Warning! This will change if we upgrade to OpenTelemetry 2 or greater!
+  const otelSymbol = Symbol.for("opentelemetry.js.api.1");
+  const existing = globalThis_any[otelSymbol];
+
+  if (existing) {
+    console.log("Found existing OpenTelemetry instance, deregistering it");
+    globalThis_any[otelSymbol] = undefined;
+  }
+}
 
 /******************************************************************************/
 /* Context management */
@@ -272,18 +289,8 @@ export function startTracing(env: Environment): void {
     // them back up above.
     autoDetectResources: false,
     instrumentations: [getNodeAutoInstrumentations()],
+    contextManager: new RootContextManager(),
   });
-
-  // For reasons that are unclear to me, we need the context manager
-  // set before the SDK is started, but the top level span stuff
-  // after the SDK is started.
-  // I'm sure my therapist will love hearing about this in 15 years.
-  //
-  // See the large comment near `RootContextManager` for more details
-  // on why we need all the stuff below.
-  const contextManager = new RootContextManager();
-  contextManager.enable();
-  api.context.setGlobalContextManager(contextManager);
 
   sdk.start();
 


### PR DESCRIPTION
## What:
This PR, at great cost to my mental health, fixes the issue preventing us from sending OpenTelemetry metrics from Cursor users.

## How:
To make a very long story short, we observed that all spans being sent while in a Cursor-launched Semgrep extension session would be processed as if they had recording as off, even when you monkeypatched it to be `true` or otherwise mandated it. 

After, we discovered that Cursor ships with its own OpenTelemetry library, located at `/Applications/Cursor.app/Contents/Resources/app/node_modules/@opentelemetry`, while VS Code did not. We began to suspect that something about Cursor's OpenTelemetry set-up was mucking with our own attempt to set up.

After chasing down the run-time imports, we concluded they were the same, but the global state of the program environment was different. It turns out that something (likely Cursor) had previous ly ran the [`registerGlobal` function](https://github.com/open-telemetry/opentelemetry-js/blob/cb42f7d511a1b54d12d32a6a6bdc6266d5569c1b/api/src/internal/global-utils.ts#L33), which shut us out from being able to do our own metrics.

The fix ended up being following the trail of global state to find the same place that `opentelemetry` stores its information, and then brutally, mercilessly ripping it out.

That's what this PR does.

## Test plan:
Extensive testing by running the extension locally and verifying that metrics do now properly send (in expected fashion) to the local endpoint. I verified that spans sent to prod showed up in Datadog also. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
