### PR TITLE
fix: terminate lsp process properly to prevent high memory usage

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -266,9 +266,9 @@ async function stop(env: Environment | null): Promise<void> {
   if (!client) {
     return;
   }
-  client.sendRequest("shutdown").then(async () => {
+  await client.sendRequest("shutdown").then(() => {
     env?.logger.log("Exiting");
-    await client.sendRequest("exit");
+    client.sendRequest("exit");
   });
   client.stop();
   env?.logger.log("Language client stopped...");


### PR DESCRIPTION
## What:

This PR helps us properly terminate the `semgrep` processes started by the extension. It changes `stop` such that we complete shutdown before stopping the client.

## Why:

It seems like LSP instances are not properly killed, leading to high memory usage when the IDE extension is being used 😢  (reported here https://linear.app/semgrep/issue/SAF-2171/high-memory-usage-due-to-multiple-semgrep-processes-in-ide)

## Test plan:

`restartLsp` calls the same `stop` function as `deactivateLsp`, which we use when we want to shutdown the process. So, I used it to test if we are able to actually terminate processes that we don't need.

Before the change, if I call `restartLsp` repeatedly, it doesn't actually shutdown previous spun up process, so the processes just accumulate.

https://github.com/user-attachments/assets/d111eae9-71fe-4b93-bc11-d1143bd2899d

After the change, there is only one process running even when I call `restartLsp` repeatedly.

https://github.com/user-attachments/assets/e5609049-ece7-4f49-96ca-3aafc2c62e4c

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)