### PR TITLE
chore(telemetry): add machine ID

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode";
 import type { Environment } from "../env";
 import { startTracing, stopTracing } from "../utilities/tracing";
 

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -19,6 +19,7 @@ import {
   type Connection,
 } from "vscode-languageserver";
 import { StackContextManager } from "@opentelemetry/sdk-trace-web";
+import * as vscode from "vscode";
 
 /******************************************************************************/
 /* Prelude */
@@ -288,6 +289,7 @@ export function startTracing(env: Environment): void {
     ["arch"]: process.arch,
     ["process.runtime.name"]: "node",
     ["process.runtime.version"]: process.versions.node,
+    ["machine_id"]: vscode.env.machineId,
     ["trace_id"]: topLevelSpan?.spanContext().traceId,
   };
 


### PR DESCRIPTION
This PR adds the `machineId` to our telemetry, which identifies a given machine according to VS Code's API. I thought I did this before, but I didn't.

Test plan:
<img width="708" height="343" alt="image" src="https://github.com/user-attachments/assets/97b51bda-702b-4cf9-9abd-fb30e911302c" />


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
