### PR TITLE
feat: add mcp setup flow

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -102,12 +102,15 @@ export function registerCommands(env: Environment): Disposable[] {
     }),
 
     vscode.commands.registerCommand("semgrep.mcpSetup", async () => {
-      // For now, only set up MCP for Cursor
       const repoPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
       if (
+        // make sure the repo path is valid
         !repoPath ||
+        // For now, only set up MCP for Cursor
         vscode.env.uriScheme !== "cursor" ||
+        // and not if the user has already said no
         env.foldersWithNoMcpSetupNudges.includes(repoPath) ||
+        // and not if the user seems to have set it up already
         fs.existsSync(path.join(repoPath, ".cursor", "rules", "semgrep.mdc"))
       ) {
         return;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,9 @@ import { handleSearch } from "./search";
 import { encodeUri } from "./showAstDocument";
 import { applyFixAndSave, isRealFileEditor, replaceAll } from "./utils";
 import type { ViewResults } from "./webviews/types/results";
+import { setupMcp } from "./mcp";
+import fs from "fs";
+import path from "node:path";
 
 /*****************************************************************************/
 /* Prelude */
@@ -95,6 +98,35 @@ export function registerCommands(env: Environment): Disposable[] {
         } else if (resp == "Do not show again") {
           env.showNudges = false;
         }
+      }
+    }),
+
+    vscode.commands.registerCommand("semgrep.mcpSetup", async () => {
+      // For now, only set up MCP for Cursor
+      const repoPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (
+        !repoPath ||
+        vscode.env.uriScheme !== "cursor" ||
+        env.foldersWithNoMcpSetupNudges.includes(repoPath) ||
+        fs.existsSync(path.join(repoPath, ".cursor", "rules", "semgrep.mdc"))
+      ) {
+        return;
+      }
+      const resp = await vscode.window.showInformationMessage(
+        "Would you like to set up MCP scanning with Semgrep in this repository?",
+        "Yes",
+        "No",
+      );
+      if (resp == "Yes") {
+        // TODO: handle multi-workspace case?
+        if (repoPath) {
+          await setupMcp(repoPath);
+        }
+      } else if (resp == "No") {
+        env.foldersWithNoMcpSetupNudges = [
+          ...env.foldersWithNoMcpSetupNudges,
+          repoPath,
+        ];
       }
     }),
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -116,16 +116,16 @@ export function registerCommands(env: Environment): Disposable[] {
         return;
       }
       const resp = await vscode.window.showInformationMessage(
-        "Would you like to set up MCP scanning with Semgrep in this repository?",
-        "Yes",
-        "No",
+        "Would you like to set up remote MCP scanning with Semgrep in this repository? [Learn more](https://mcp.semgrep.ai/)",
+        "Set up",
+        "Do not show again",
       );
-      if (resp == "Yes") {
+      if (resp == "Set up") {
         // TODO: handle multi-workspace case?
         if (repoPath) {
           await setupMcp(repoPath);
         }
-      } else if (resp == "No") {
+      } else if (resp == "Do not show again") {
         env.foldersWithNoMcpSetupNudges = [
           ...env.foldersWithNoMcpSetupNudges,
           repoPath,

--- a/src/env.ts
+++ b/src/env.ts
@@ -133,6 +133,14 @@ export class Environment {
     this.context.globalState.update("showNudges", val);
   }
 
+  get foldersWithNoMcpSetupNudges(): string[] {
+    return this.context.globalState.get("foldersWithNoMcpSetupNudges", []);
+  }
+
+  set foldersWithNoMcpSetupNudges(val: string[]) {
+    this.context.globalState.update("foldersWithNoMcpSetupNudges", val);
+  }
+
   get newInstall(): boolean {
     return this.context.globalState.get("newInstall", true);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,6 +107,7 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
       }
     }
   });
+  vscode.commands.executeCommand("semgrep.mcpSetup");
 }
 
 export async function activate(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,47 @@
+import * as vscode from "vscode";
+import fs from "fs";
+import path from "node:path";
+
+const mcpRuleText = `---
+alwaysApply: true
+---
+- Always look first to any semgrep mcp servers for code security needs
+- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the security_check tool
+`;
+
+export async function setupMcp(repoPath: string): Promise<void> {
+  const mcpRulePath = path.join(repoPath, ".cursor", "rules", "semgrep.mdc");
+  const mcpJsonPath = path.join(repoPath, ".cursor", "mcp.json");
+  const serverInfo = {
+    type: "streamable-http",
+    url: "https://mcp.semgrep.ai/mcp",
+  };
+  let mcpJsonContents: any;
+  if (fs.existsSync(mcpJsonPath)) {
+    mcpJsonContents = JSON.parse(
+      await vscode.workspace.fs
+        .readFile(vscode.Uri.parse(mcpJsonPath))
+        .then((buf) => buf.toString()),
+    );
+    // TODO: could overwrite
+    mcpJsonContents.mcpServers["semgrep"] = serverInfo;
+  } else {
+    mcpJsonContents = {
+      mcpServers: {
+        semgrep: serverInfo,
+      },
+    };
+  }
+  await vscode.workspace.fs.writeFile(
+    vscode.Uri.parse(mcpRulePath),
+    new TextEncoder().encode(mcpRuleText),
+  );
+  await vscode.workspace.fs.writeFile(
+    vscode.Uri.parse(mcpJsonPath),
+    new TextEncoder().encode(JSON.stringify(mcpJsonContents)),
+  );
+
+  vscode.window.showInformationMessage(
+    "MCP setup completed, finish by enabling the `semgrep` MCP server. Happy vibe coding!",
+  );
+}


### PR DESCRIPTION
## What:
This PR adds an MCP setup flow to the IDE, which will prompt users on whether they want to use the Semgrep MCP server to secure their code.

## Why:
We want to make MCP installation even easier for users.

## How:
We have a nudge, which allows users to hit "Yes", which will install a repo-local cursor rule and repo-local MCP, or "No", which will silence the nudge for that repository.

## Test plan:
I tested:
- this nudge does not appear when a `semgrep.mdc` exists
- hitting "Yes" on a fresh repo, then enabling the MCP, causes the Cursor agent to properly invoke `security_check`
- hitting "No" on a repo causes the nudge to no longer appear when navigating back to the same repo

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
