### PR TITLE
feat: add secrets setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- Added new experimental `Semgrep: Secrets` setting to use Secrets product in experimental IDE
+
 ## 1.13.0 - 2025-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The following experimental features should only be used upon recommendation by S
 
 - **Semgrep > Ignore Cli Version**: Ignore the CLI Version and enable all extension features.
 - **Semgrep > Use experimental language server**: Use the new experimental language server
+- **Semgrep › Scan: Secrets**: Enable Secrets scanning using the Pro Engine.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The following experimental features should only be used upon recommendation by S
 
 - **Semgrep > Ignore Cli Version**: Ignore the CLI Version and enable all extension features.
 - **Semgrep > Use experimental language server**: Use the new experimental language server
-- **Semgrep › Scan: Secrets**: Enable Secrets scanning using the Pro Engine.
+- **Semgrep › Scan: Secrets**: Enable Secrets scanning using the Pro Engine (requires experimental language server).
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
         "semgrep.scan.secrets": {
           "type": "boolean",
           "default": false,
-          "description": "(experimental) Enable secrets scanning using the Semgrep Pro Engine (requires Pro Engine to be already installed)"
+          "description": "(experimental) Enable secrets scanning using the Semgrep Pro Engine (requires Pro Engine and experimental language server)"
         },
         "semgrep.doHover": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,11 @@
           "default": false,
           "description": "Enable intrafile scanning using the Semgrep Pro Engine (requires Pro Engine to be already installed)"
         },
+        "semgrep.scan.secrets": {
+          "type": "boolean",
+          "default": false,
+          "description": "(experimental) Enable secrets scanning using the Semgrep Pro Engine (requires Pro Engine to be already installed)"
+        },
         "semgrep.doHover": {
           "type": "boolean",
           "default": false,

--- a/src/utilities/tracing.ts
+++ b/src/utilities/tracing.ts
@@ -281,6 +281,7 @@ export function startTracing(env: Environment): void {
       env.extensionDevEnvironment,
     ),
     ["client.proIntrafile"]: env.config.cfg.get("scan.pro_intrafile"),
+    ["client.secrets"]: env.config.cfg.get("scan.secrets"),
     ["client.experimentalLs"]: env.config.cfg.get("useExperimentalLS"),
     ["client.metrics"]: hasMetrics,
     // Not exactly the same as the auto-collected OpenTelemetry


### PR DESCRIPTION
This PR adds an experimental setting to enable the Secrets product in the experimental IDE.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
