### PR TITLE
fix: properly wait for shutdown and exit request to complete

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -27,6 +27,7 @@ import {
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
 import { setupLanguageClientTracing, topLevelSpan } from "./utilities/tracing";
+import { exit } from "./lspExtensions";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {
@@ -268,7 +269,7 @@ async function stop(env: Environment | null): Promise<void> {
   }
   await client.sendRequest("shutdown");
   env?.logger.log("Exiting");
-  await client.sendRequest("exit");
+  await client.sendNotification(exit);
   client.stop();
   env?.logger.log("Language client stopped...");
 }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -269,7 +269,7 @@ async function stop(env: Environment | null): Promise<void> {
   }
   await client.sendRequest("shutdown");
   env?.logger.log("Exiting");
-  await client.sendNotification(exit);
+  await client.sendNotification("exit");
   client.stop();
   env?.logger.log("Language client stopped...");
 }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -27,7 +27,6 @@ import {
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
 import { setupLanguageClientTracing, topLevelSpan } from "./utilities/tracing";
-import { exit } from "./lspExtensions";
 
 const execShell = (cmd: string, args: string[]) =>
   new Promise<string>((resolve, reject) => {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -266,10 +266,9 @@ async function stop(env: Environment | null): Promise<void> {
   if (!client) {
     return;
   }
-  await client.sendRequest("shutdown").then(() => {
-    env?.logger.log("Exiting");
-    client.sendRequest("exit");
-  });
+  await client.sendRequest("shutdown");
+  env?.logger.log("Exiting");
+  await client.sendRequest("exit");
   client.stop();
   env?.logger.log("Language client stopped...");
 }

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -93,3 +93,5 @@ export const searchOngoing = new lc.RequestType0<SearchResults, void>(
 export const showAst = new lc.RequestType<ShowAstParams, string, void>(
   "semgrep/showAst",
 );
+
+export const exit = new lc.NotificationType0("semgrep/exit");

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -93,5 +93,3 @@ export const searchOngoing = new lc.RequestType0<SearchResults, void>(
 export const showAst = new lc.RequestType<ShowAstParams, string, void>(
   "semgrep/showAst",
 );
-
-export const exit = new lc.NotificationType0("semgrep/exit");


### PR DESCRIPTION
## Why:

It seems like LSP instances are not properly killed, leading to high memory usage when the IDE extension is being used 😢 (reported [here](https://linear.app/semgrep/issue/SAF-2171/high-memory-usage-due-to-multiple-semgrep-processes-in-ide))

The [previous fix](https://github.com/semgrep/semgrep-vscode/pull/253) for the memory issue [doesn't fully fix the issue](https://github.com/semgrep/semgrep-vscode/pull/253#discussion_r2285507670), because we are waiting on only the shutdown request to finish but not the exit request, [which actually sets the server's state to `Stopped`.](https://github.com/semgrep/semgrep-proprietary/blob/2e5d062d40eb550149fe65bd16d72cf715ddd49c/src/lsp_pro/notifications/Notification_handler.ml#L130)

We also send an exit _request_ when we only handle an exit _notification_ on the LSP server. This also prevents the Semgrep process from properly terminating.

## What:

This PR fixes the problems by

1. waiting on both the shutdown and exit requests
2. sending a notification instead of a request for exit

Together with the [PR](https://github.com/semgrep/semgrep-proprietary/pull/4479) in `semgrep-proprietary`, it should fix the problem.

## Test plan:

You can see the "Server Exited" notification dialog that indicates the exit request was successfully handled when we restart the language server.

![nice.gif](https://app.graphite.dev/user-attachments/assets/b44103c4-269a-44d5-9199-f1f9c772bec3.gif)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)