### PR TITLE
fix: end existing clients on new start and properly await stop

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -169,9 +169,6 @@ export class Environment {
   }
 
   get client(): LanguageClient | null {
-    if (!this._client) {
-      window.showWarningMessage("Semgrep Language Server not active");
-    }
     return this._client;
   }
 

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -220,6 +220,12 @@ async function start(env: Environment): Promise<void> {
   // TODO: Remove when semgrep is no longer experimental on Windows.
   if (process.platform === "win32") process.env.SEMGREP_FORCE_INSTALL = "1";
 
+  if (env.client) {
+    env.logger.log("Language client already running, stopping it...");
+    await env.client.stop();
+    env.client = null;
+  }
+
   // Compute LSP server and client options
   const [serverOptions, clientOptions] = await lspOptions(env);
 
@@ -266,10 +272,7 @@ async function stop(env: Environment | null): Promise<void> {
   if (!client) {
     return;
   }
-  await client.sendRequest("shutdown");
-  env?.logger.log("Exiting");
-  await client.sendNotification("exit");
-  client.stop();
+  await client.stop();
   env?.logger.log("Language client stopped...");
 }
 


### PR DESCRIPTION
This PR makes it so:
1. When starting a new language client (such as on workspace change), we properly `.stop()` the old one. Otherwise, we overwrite it and never can access its value again.
2. We properly `await` the `.stop()` method.


## Test plan:
Verified that processes do not pile up on workspace change. Remains to be seen for `restart`.


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
