### PR TITLE
chore: set output channel names for client and server

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -209,7 +209,7 @@ export class Environment {
 
   static async create(context: ExtensionContext): Promise<Environment> {
     const config = await Environment.loadConfig(context);
-    const channel = window.createOutputChannel(VSCODE_EXT_NAME);
+    const channel = window.createOutputChannel(VSCODE_EXT_NAME + " (Client)");
     const logger = new Logger(config.trace, channel);
     const documentView = new SemgrepDocumentProvider();
     return new Environment(context, documentView, channel, logger, config);

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -23,6 +23,7 @@ import {
   DIAGNOSTIC_COLLECTION_NAME,
   DIST_BINARY_PATH,
   VERSION_PATH,
+  VSCODE_EXT_NAME,
 } from "./constants";
 import type { Environment } from "./env";
 import { type LspErrorParams, rulesRefreshed } from "./lspExtensions";
@@ -191,6 +192,7 @@ async function lspOptions(
     diagnosticCollectionName: DIAGNOSTIC_COLLECTION_NAME,
     // TODO: should we limit to support languages and keep the list manually updated?
     documentSelector: [{ language: "*", scheme: "file" }],
+    outputChannelName: VSCODE_EXT_NAME + " (Server)",
     traceOutputChannel: env.channel,
     initializationOptions: initializationOptions,
     // OLD: This used to be a Sentry error handler.


### PR DESCRIPTION
This PR sets the names of the output channels for the client and the server so that they are distingushable in VSCode.

## Test plan:

![image.png](https://app.graphite.dev/user-attachments/assets/8375a824-e2d2-43df-99e9-b17ff7d55ad2.png)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)