### PR TITLE
fix: update cursor rule to say `semgrep_scan`

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,7 +6,7 @@ const mcpRuleText = `---
 alwaysApply: true
 ---
 - Always look first to any semgrep mcp servers for code security needs
-- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the security_check tool
+- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the semgrep_scan tool
 `;
 
 export async function setupMcp(repoPath: string): Promise<void> {


### PR DESCRIPTION
The cursor rule added by the MCP setup prompt has been updated to call `semgrep_scan` instead of `security_check`. We have also removed the `security_check` tool. We should update the cursor rule here to match.

Test plan: the cursor rule added should say `semgrep_scan` instead.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
