### PR TITLE
Add supply chain to MCP setup

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,7 +6,8 @@ const mcpRuleText = `---
 alwaysApply: true
 ---
 - Always look first to any semgrep mcp servers for code security needs
-- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the semgrep_scan tool
+- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the semgrep_scan tool. If you change any lockfile, you MUST run the semgrep_supply_chain tool. 
+
 `;
 
 export async function setupMcp(repoPath: string): Promise<void> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,7 +6,7 @@ const mcpRuleText = `---
 alwaysApply: true
 ---
 - Always look first to any semgrep mcp servers for code security needs
-- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the semgrep_scan tool. If you change any lockfile, you MUST run the semgrep_supply_chain tool. 
+- Whenever you generate code or commands, you MUST first ensure safety by scanning the content with the semgrep_scan tool. If you change any lockfile, you MUST run the semgrep_supply_chain tool.
 
 `;
 


### PR DESCRIPTION
This PR adds an instruction to run the semgrep_supply_chain tool when lockfiles are changed