### PR TITLE
chore: prep vscode for dynamic linking

### DIFF
--- a/download-osemgrep-pro.sh
+++ b/download-osemgrep-pro.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 set -eu
 uname=$1
+is_musl() {
+    ldd --version 2>&1 | grep -q musl
+}
+# NOTE: the `machine=` naming is a historic artifact from when we used to only publish
+# a statically linked binary that didn't depend on the user's libc
+#
+# NOTE: the pypi tags MUST match the pypi tags we publish in pypi; if we modify
+# the released tags we must make sure they match
 case "${uname}" in
-    linux-x64*)    machine=manylinux;;
-    linux-arm64*)   machine=linux-arm64;;
-    darwin-x64*)   machine=osx;;
-    darwin-arm64)    machine=osx-m1;;
-    win32-x64*)   machine=windows;;
-    *)    machine=manylinux;;
+    linux-x64*)
+        if is_musl; then
+            # NOTE: not manylinux! this is a musl binary
+            machine=manylinux
+            PLATFORM="musllinux_1_2_x86_64"
+        else
+            machine=manylinux-x86
+            PLATFORM="manylinux_2_35_x86_64"
+        fi
+        ;;
+    linux-arm64*)
+        if is_musl; then
+            machine=linux-arm64
+            PLATFORM="musllinux_1_2_aarch64"
+        else
+            machine=manylinux-arm64
+            PLATFORM="manylinux_2_35_aarch64"
+        fi
+        ;;
+    darwin-x64*)   machine=osx;   PLATFORM="macosx_10_14_x86_64";;
+    darwin-arm64)  machine=osx-m1; PLATFORM="macosx_11_0_arm64";;
+    win32-x64*)    machine=windows; PLATFORM="win_amd64";;
+    *)             machine=manylinux; PLATFORM="manylinux_2_35_x86_64";;
 esac
 # NOT the same as the semgrep version!!!!
 release_char_count=$(echo "release-" | wc -c)
@@ -27,15 +52,29 @@ mkdir -p dist
 echo "Downloading osemgrep-pro binary from S3 for version ${machine}-${OSEMGREP_PRO_VERSION}"
 aws s3 cp "s3://deep-semgrep-artifacts/${BINARY}${EXT}" dist/osemgrep-pro${EXT}
 echo "Downloaded osemgrep-pro binary"
+
+version_gt() {
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ] && [ "$1" != "$2" ]
+}
+
 if [ "${machine}" = "windows" ]; then
     echo "Downloading the Windows wheel for the DLLs"
-    PLATFORM="win_amd64"
     pip download "semgrep==${OSEMGREP_PRO_VERSION}" --no-deps --platform ${PLATFORM} -d /tmp/
     echo "Unzipping the Windows wheel"
-    unzip -q -o /tmp/"semgrep-${OSEMGREP_PRO_VERSION}"-*-${PLATFORM}.whl -d /tmp/
+    unzip -q -o /tmp/"semgrep-${OSEMGREP_PRO_VERSION}"-*.whl -d /tmp/
     echo "Copying the DLLs to the dist directory"
     cp -r /tmp/"semgrep-${OSEMGREP_PRO_VERSION}.data"/purelib/semgrep/bin/*.dll dist/
 else
     echo "Making osemgrep-pro binary executable"
     chmod +x dist/osemgrep-pro
+    # preserve backwards compatibility with statically linked macos/linux
+    # binaries
+    if version_gt "${OSEMGREP_PRO_VERSION}" "1.157.0"; then
+        echo "Downloading the wheel for the shared libraries"
+        pip download "semgrep==${OSEMGREP_PRO_VERSION}" --no-deps --platform ${PLATFORM} -d /tmp/
+        echo "Extracting the wheel"
+        unzip -q -o /tmp/"semgrep-${OSEMGREP_PRO_VERSION}"-*.whl -d /tmp/
+        echo "Copying the shared libraries to the dist directory"
+        cp -LR /tmp/"semgrep-${OSEMGREP_PRO_VERSION}.data"/purelib/semgrep/bin/libs dist/libs
+    fi
 fi


### PR DESCRIPTION
Now that we dynamicly link the semgrep-proprietary + semgrep binary; we need to prep the vscode extension to copy the libs from the pypi wheels for both linux and macos.

test plan:

- preform a pypi test release with a wheel that contains dynamically linked semgrep-core binaries (see: https://test.pypi.org/project/semgrep/1.157.123/#files)
- CI in https://github.com/semgrep/semgrep-vscode/pull/309; which downloads the wheel and extracts the shared lib from the wheel + downloads the semgrep binary from the most current commit on semgrep/semgrep-proprietary's develop (which is dynamically linked)
    - Also: inspecting the macos logs to see if the binary downloaded is not staticly linked https://github.com/semgrep/semgrep-vscode/actions/runs/23961147551/job/69891034205 (see: the added `otool -L` in the download script)
- CI on this PR to check we are backwards compatible w/statically linked semgrep.

resolves ENGINE-2533

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)