### PR TITLE
feat: add semgrep.appUrl setting to configure SEMGREP_APP_URL for LSP daemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable hovering for AST node viewing (requires restart)"
+        },
+        "semgrep.appUrl": {
+          "type": "string",
+          "default": "",
+          "description": "URL of the Semgrep App to use (e.g. https://semgrep.dev). Passed to the language server as SEMGREP_APP_URL. Leave empty to use the default."
         }
       }
     },

--- a/src/env.ts
+++ b/src/env.ts
@@ -62,6 +62,10 @@ export class Config {
     return this.cfg.get<string>("path") ?? "semgrep";
   }
 
+  get appUrl(): string {
+    return this.cfg.get<string>("appUrl") ?? "";
+  }
+
   get onlyGitDirty(): boolean {
     return this.cfg.get<boolean>("scan.onlyGitDirty") ?? false;
   }

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -145,12 +145,16 @@ async function serverOptionsCli(
   server.args = cmdlineOpts;
 
   const options: ExecutableOptions = {};
+  const extraEnv: Record<string, string> = {};
   if (topLevelSpan) {
-    options.env = {
-      ...process.env,
-      SEMGREP_TRACE_PARENT_SPAN_ID: topLevelSpan.spanContext().spanId,
-      SEMGREP_TRACE_PARENT_TRACE_ID: topLevelSpan.spanContext().traceId,
-    };
+    extraEnv.SEMGREP_TRACE_PARENT_SPAN_ID = topLevelSpan.spanContext().spanId;
+    extraEnv.SEMGREP_TRACE_PARENT_TRACE_ID = topLevelSpan.spanContext().traceId;
+  }
+  if (env.config.appUrl) {
+    extraEnv.SEMGREP_APP_URL = env.config.appUrl;
+  }
+  if (Object.keys(extraEnv).length > 0) {
+    options.env = { ...process.env, ...extraEnv };
   }
   server.options = options;
 


### PR DESCRIPTION
## Summary

- Adds a new `semgrep.appUrl` VS Code setting (string, default empty) for configuring the Semgrep App URL
- Passes the value as `SEMGREP_APP_URL` in the environment of the spawned LSP daemon process
- No-op when left empty (default behavior unchanged)

### Why:
People who are on a separate tenant has been having trouble logging in to the IDE extension. I suspect that it is because there is no way to configure the `SEMGREP_APP_URL` for the LSP daemon that we spawn in the IDE extension.

## Test plan

- [ ] Set `semgrep.appUrl` to a custom URL in VS Code settings, restart the extension, and verify the LSP daemon receives `SEMGREP_APP_URL` in its environment
- [ ] Leave `semgrep.appUrl` empty and verify no `SEMGREP_APP_URL` is set (existing behavior unchanged)
- [ ] Login to a tenant and check that the extension works

🤖 Generated with [Claude Code](https://claude.com/claude-code)