### PR TITLE
ci: sign release commits via create-pull-request [SEC-2046]

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Authenticate as semgrep-ide-plugins-release
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ vars.SEMGREP_IDE_PLUGINS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMGREP_IDE_PLUGINS_RELEASE_PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.3
         with:
@@ -25,43 +31,14 @@ jobs:
           SEMGREP_STATIC_VERSION: "release-${{ inputs.version }}"
         run: |
           echo "${SEMGREP_STATIC_VERSION}" > semgrep-version
-      - name: Commit and push
-        id: commit
-        env:
-          NEW_SEMGREP_VERSION: "${{ github.event.inputs.version }}"
-          GITHUB_ACTOR: "${{ github.actor }}"
-          GITHUB_RUN_ID: "${{ github.run_id }}"
-          GITHUB_RUN_ATTEMPT: "${{ github.run_attempt }}"
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          BRANCH="gha/bump-version-${NEW_SEMGREP_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          SUBJECT="Bump semgrep to ${NEW_SEMGREP_VERSION}"
-          git checkout -b "${BRANCH}"
-          git add .
-          git commit -m "${SUBJECT}"
-          git push --set-upstream origin "${BRANCH}"
-          echo "branch=${BRANCH}" >> "${GITHUB_OUTPUT}"
-          echo "subject=${SUBJECT}" >> "${GITHUB_OUTPUT}"
-      - name: bump package patch version
-        run: |
-          npm version patch
-          git push
-      - name: Create PR
-        id: open-pr
-        env:
-          SOURCE: "${{ steps.commit.outputs.branch }}"
-          TARGET: "${{ github.event.repository.default_branch }}"
-          TITLE: "chore: Release Version ${{ inputs.version }}"
-          VERSION: "${{ inputs.version }}"
-          GH_TOKEN: "${{ github.token }}"
-        run: |
-          # check if the branch already has a pull request open
-          if gh pr list --head "${SOURCE}" | grep -vq "no pull requests"; then
-              # pull request already open
-              echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
-              echo "cancelling release"
-              exit 1
-          fi
-          # open new pull request with the body of from the local template.
-          gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" --base "${TARGET}" --head "${SOURCE}"
+      - name: Bump package patch version
+        run: npm version patch --no-git-tag-version
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          sign-commits: true
+          branch: gha/bump-version-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          commit-message: "Bump semgrep to ${{ inputs.version }}"
+          title: "chore: Release Version ${{ inputs.version }}"
+          body: "Bump Semgrep Version to ${{ inputs.version }}"


### PR DESCRIPTION
## Problem

The default `secrets.GITHUB_TOKEN` runs as `github-actions[bot]` and produces unsigned commits

## Solution

Replace the manual `git push` + `gh pr create` flow with [`step-securitycreate-pull-request`](https://github.com/peter-evans/create-pull-request) using `sign-commits: true`. The action commits via the GitHub API, so commits are signed

## Verification

Produced this PR https://github.com/semgrep/semgrep-vscode/pull/314
