### PR TITLE
ci: inline SHA-pinned pre-commit (fix broken reusable-workflow call) [SEC-2478]

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,14 +29,14 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: .pre-commit-config.yaml
-          version: "0.11.15"
+          version: "0.11.x"
       - name: Cache pre-commit hook envs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-v1|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install pre-commit
-        run: uv tool install pre-commit --with pre-commit-uv
+        run: UV_EXCLUDE_NEWER="1 week" uv tool install pre-commit --with pre-commit-uv
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
   github-actions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,6 @@ jobs:
   # Running pre-commit in CI. See .pre-commit-config.yaml for our pre-commit
   # configuration. Dogfood: we run Semgrep inside pre-commit, so this also
   # tests how semgrep interacts with pre-commit.
-  #
-  # Inlined (rather than calling the shared reusable workflow) because this is
-  # a public repo, and public repos can't call reusable workflows in the
-  # internal semgrep/release-workflows repo. Actions are SHA-pinned to match.
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,12 +8,37 @@ on:
       - develop
 
 jobs:
-  # Running pre-commit in CI via the shared reusable workflow. See
-  # .pre-commit-config.yaml for our pre-commit configuration.
-  # Dogfood: we run Semgrep inside pre-commit, so this also tests how
-  # semgrep interacts with pre-commit.
+  # Running pre-commit in CI. See .pre-commit-config.yaml for our pre-commit
+  # configuration. Dogfood: we run Semgrep inside pre-commit, so this also
+  # tests how semgrep interacts with pre-commit.
+  #
+  # Inlined (rather than calling the shared reusable workflow) because this is
+  # a public repo, and public repos can't call reusable workflows in the
+  # internal semgrep/release-workflows repo. Actions are SHA-pinned to match.
   pre-commit:
-    uses: semgrep/release-workflows/.github/workflows/pre-commit.yaml@c04907222197635bc8fc0d80b1d5fec8f945eb43 # develop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Honor .python-version
+        if: hashFiles('.python-version') != ''
+        run: echo "UV_PYTHON=$(cat .python-version)" >> "$GITHUB_ENV"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: .pre-commit-config.yaml
+          version: "0.11.15"
+      - name: Cache pre-commit hook envs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-v1|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: uv tool install pre-commit --with pre-commit-uv
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
   github-actions:
     runs-on: ubuntu-latest
     steps:

--- a/src/webviews/utilities/vscode.ts
+++ b/src/webviews/utilities/vscode.ts
@@ -21,8 +21,7 @@ class VSCodeAPIWrapper {
   // This is set by the webview App.tsx!
   public onUpdate: ((results: ViewResults) => void) | null = null;
   public onUpdateActiveLang:
-    | ((activeLang: SearchLanguage | null) => void)
-    | null = null;
+    ((activeLang: SearchLanguage | null) => void) | null = null;
   public onClear: (() => void) | null = null;
   public onExportRule: (() => void) | null = null;
 


### PR DESCRIPTION
https://github.com/semgrep/semgrep-vscode/pull/329

Actually this can't reference a private repo so just inline it