### PR TITLE
feat: dedicated Findings view in the Semgrep sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,10 @@
     "views": {
       "semgrep-sidebar": [
         {
+          "id": "semgrep.view.findings",
+          "name": "Findings"
+        },
+        {
           "id": "semgrep.view.policy",
           "name": "Policy Configuration"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,10 @@ import { activateLsp, deactivateLsp, restartLsp } from "./lsp";
 import { createStatusBar } from "./statusBar";
 import { initTelemetry, stopTelemetry } from "./telemetry/telemetry";
 import { deregisterExistingOtel, withSpan } from "./utilities/tracing";
+import {
+  SemgrepFindingsViewProvider,
+  registerOpenFindingCommand,
+} from "./views/findings";
 import { SemgrepPolicyViewProvider } from "./views/policy";
 import { SemgrepHelpProvider } from "./views/support";
 import { SemgrepSearchWebviewProvider } from "./views/webview";
@@ -66,6 +70,13 @@ async function afterClientStart(context: ExtensionContext, env: Environment) {
       SemgrepPolicyViewProvider.viewType,
       new SemgrepPolicyViewProvider(context.extensionUri, env),
     ),
+  );
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider(
+      SemgrepFindingsViewProvider.viewType,
+      new SemgrepFindingsViewProvider(),
+    ),
+    registerOpenFindingCommand(),
   );
 
   // Handle configuration changes

--- a/src/test/fixtures/hermetic/README.md
+++ b/src/test/fixtures/hermetic/README.md
@@ -1,0 +1,61 @@
+# Hermetic findings fixtures
+
+Small, deterministic fixtures for exercising the Semgrep language server with
+**local rules** (no network, no `--config=auto`, no login). Intended as the
+basis for future tests of the findings view (see the "Dedicated Findings panel"
+plan).
+
+- `ws/` — a tiny fixture workspace (`login.py`, `config.py`).
+- `rules/rules.yaml` — local rules that fire at known lines/severities.
+
+Verified with the CLI as an oracle:
+
+```
+semgrep --config rules/rules.yaml --json ws
+```
+
+produces exactly three findings:
+
+| file        | rule                        | line (1-based) | severity |
+| ----------- | --------------------------- | -------------- | -------- |
+| `login.py`  | `tainted-sql-string`        | 7              | ERROR    |
+| `config.py` | `hardcoded-aws-key`         | 2              | WARNING  |
+| `config.py` | `placeholder-password-note` | 3              | INFO     |
+
+> `config.py` contains an AWS **documentation example** key
+> (`AKIAIOSFODNN7EXAMPLE`) — not a real credential.
+
+## Diagnostic contract (what a findings view can rely on)
+
+Established by driving `semgrep lsp` directly and observing
+`textDocument/publishDiagnostics`. Each diagnostic contains **only**:
+
+```
+code, message, range, severity, source(, codeDescription)
+```
+
+Notable facts for anyone building on the diagnostics:
+
+- **`source` is `"Semgrep"`** — a stable filter key.
+- **`code` is the rule id, prefixed by the config source.** File-loaded rules
+  are namespaced by the rules-file stem (e.g. `rules.tainted-sql-string`), and
+  an absolute config path namespaces by the whole path. A short label must
+  strip that prefix. Registry/policy rules use the full dotted id.
+- **`range.start.line` is 0-based** (LSP), i.e. one less than the editor line.
+- **Severity is Error/Warning/Info only (LSP 1/2/3).** There is **no** 4th
+  ("Critical") level, and **no `data` payload / product field** — verified on
+  both the OSS engine and the bundled Pro engine while logged in to a
+  deployment. So a Snyk-style 4-level severity or per-product (Code / Supply
+  Chain / Secrets) grouping is **not derivable from the LSP diagnostic today**
+  and would require a language-server change to expose that metadata.
+
+## Notes for testing against the LS
+
+- The LS only scans **untracked/changed** files. A committed-clean or non-git
+  workspace yields zero diagnostics; the heavy suite handles this via
+  `git rm --cached`.
+- The LS publishes diagnostics on `textDocument/didOpen`; opening the fixture
+  documents is the reliable trigger.
+- An ambient `SEMGREP_APP_TOKEN` (e.g. exported from a shell profile) logs the
+  LS in and makes it run **deployment-policy** rules instead of these local
+  ones — anything hermetic must run logged out.

--- a/src/test/fixtures/hermetic/rules/rules.yaml
+++ b/src/test/fixtures/hermetic/rules/rules.yaml
@@ -1,0 +1,31 @@
+# Hermetic local rules for the findings-panel PR 1 baseline suite.
+# No network, no --config=auto: deterministic findings at known lines/severities.
+# The suite asserts the diagnostic contract the findings view depends on
+# (source, code, severity, range) against these.
+rules:
+  - id: tainted-sql-string
+    languages: [python]
+    severity: ERROR
+    message: "User input reaches a SQL query string; possible SQL injection."
+    metadata:
+      category: security
+      cwe: ["CWE-89: SQL Injection"]
+    patterns:
+      - pattern: $CUR.execute("..." % $X)
+
+  - id: hardcoded-aws-key
+    languages: [python]
+    severity: WARNING
+    message: "Hardcoded AWS access key detected."
+    metadata:
+      category: security
+      cwe: ["CWE-798: Use of Hard-coded Credentials"]
+    patterns:
+      - pattern-regex: "AKIA[0-9A-Z]{16}"
+
+  - id: placeholder-password-note
+    languages: [python]
+    severity: INFO
+    message: "Informational finding used to exercise INFO-severity mapping."
+    patterns:
+      - pattern: password = "..."

--- a/src/test/fixtures/hermetic/ws/config.py
+++ b/src/test/fixtures/hermetic/ws/config.py
@@ -1,0 +1,3 @@
+# Fixture only — not a real credential. Used to exercise WARNING/INFO severities.
+AWS_SECRET_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE1234567890abcdefghij"
+password = "placeholder-not-a-secret"

--- a/src/test/fixtures/hermetic/ws/login.py
+++ b/src/test/fixtures/hermetic/ws/login.py
@@ -1,0 +1,8 @@
+import sqlite3
+
+
+def find_user(conn, email):
+    cur = conn.cursor()
+    # Tainted SQL: user input concatenated into a query string.
+    cur.execute("SELECT * FROM users WHERE email = '%s'" % email)
+    return cur.fetchall()

--- a/src/test/suite/findings.test.ts
+++ b/src/test/suite/findings.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert";
+import * as vscode from "vscode";
+
+import { codeToString, groupByFile } from "../../views/findings";
+
+// Pure logic tests for the Findings view grouping. These construct fake
+// diagnostics and exercise groupByFile/codeToString directly — no language
+// server, no scan, no VS Code UI — so they are fast and deterministic. They run
+// in the existing integration host only because `vscode` types resolve there.
+suite("Findings view — grouping logic", () => {
+  const uri = (p: string) => vscode.Uri.file(p);
+  const diag = (
+    line: number,
+    opts: {
+      source?: string;
+      code?: vscode.Diagnostic["code"];
+      message?: string;
+    } = {},
+  ): vscode.Diagnostic => {
+    const d = new vscode.Diagnostic(
+      new vscode.Range(line, 0, line, 1),
+      opts.message ?? `finding at ${line}`,
+      vscode.DiagnosticSeverity.Warning,
+    );
+    d.source = opts.source ?? "Semgrep";
+    if (opts.code !== undefined) d.code = opts.code;
+    return d;
+  };
+
+  test("keeps only Semgrep-sourced diagnostics", () => {
+    const grouped = groupByFile([
+      [uri("/a.py"), [diag(1), diag(2, { source: "eslint" })]],
+    ]);
+    assert.strictEqual(grouped.length, 1);
+    assert.strictEqual(grouped[0].findings.length, 1);
+  });
+
+  test("drops files with no Semgrep findings", () => {
+    const grouped = groupByFile([
+      [uri("/a.py"), [diag(1, { source: "eslint" })]],
+      [uri("/b.py"), [diag(1)]],
+    ]);
+    assert.deepStrictEqual(
+      grouped.map((g) => g.uri.fsPath),
+      ["/b.py"],
+    );
+  });
+
+  test("sorts files by path and findings by line", () => {
+    const grouped = groupByFile([
+      [uri("/z.py"), [diag(9), diag(2)]],
+      [uri("/a.py"), [diag(5)]],
+    ]);
+    assert.deepStrictEqual(
+      grouped.map((g) => g.uri.fsPath),
+      ["/a.py", "/z.py"],
+    );
+    assert.deepStrictEqual(
+      grouped[1].findings.map((d) => d.range.start.line),
+      [2, 9],
+    );
+  });
+
+  test("codeToString handles string, number, and {value} codes", () => {
+    assert.strictEqual(codeToString("rules.foo"), "rules.foo");
+    assert.strictEqual(codeToString(42), "42");
+    assert.strictEqual(
+      codeToString({ value: "a.b.c", target: vscode.Uri.parse("https://x") }),
+      "a.b.c",
+    );
+    assert.strictEqual(codeToString(undefined), "");
+  });
+});

--- a/src/test/suite/findings.test.ts
+++ b/src/test/suite/findings.test.ts
@@ -7,6 +7,11 @@ import { codeToString, groupByFile } from "../../views/findings";
 // diagnostics and exercise groupByFile/codeToString directly — no language
 // server, no scan, no VS Code UI — so they are fast and deterministic. They run
 // in the existing integration host only because `vscode` types resolve there.
+//
+// The fake diagnostics below mirror the real diagnostic contract documented in
+// src/test/fixtures/hermetic/README.md (source "Semgrep", rule id in `code`
+// possibly config-prefixed, 0-based line ranges) — that file also carries the
+// deterministic fixtures used for manual F5 verification of the view.
 suite("Findings view — grouping logic", () => {
   const uri = (p: string) => vscode.Uri.file(p);
   const diag = (

--- a/src/views/findings.ts
+++ b/src/views/findings.ts
@@ -1,0 +1,176 @@
+import * as vscode from "vscode";
+
+// Diagnostics published by the Semgrep language server set this `source`.
+const SEMGREP_SOURCE = "Semgrep";
+
+// A node in the Findings tree: either a file (grouping) or a finding (leaf).
+type FindingNode =
+  | { kind: "file"; uri: vscode.Uri; count: number }
+  | { kind: "finding"; uri: vscode.Uri; diagnostic: vscode.Diagnostic };
+
+/**
+ * Tree of Semgrep findings, grouped file -> finding, backed by the same
+ * diagnostics that populate the Problems tab (the "semgrep-findings"
+ * collection, filtered by `source === "Semgrep"`).
+ *
+ * This is intentionally minimal (PR 2): file -> finding, click-to-open. No
+ * severity icons, product grouping, or badges yet — the LSP diagnostic does not
+ * carry the metadata those need (see fixtures/hermetic/README.md).
+ */
+// Command that opens a finding and makes its location obvious: it selects the
+// finding's line range and reveals it centered in the viewport. Registered once
+// from extension activation.
+export const OPEN_FINDING_COMMAND = "semgrep.findings.openFinding";
+
+// A transient full-line highlight applied when a finding is opened, so the eye
+// lands on the right line. It fades out shortly after.
+const findingHighlight = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  backgroundColor: new vscode.ThemeColor("editor.rangeHighlightBackground"),
+});
+
+export function registerOpenFindingCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    OPEN_FINDING_COMMAND,
+    async (uri: vscode.Uri, range: vscode.Range) => {
+      const doc = await vscode.workspace.openTextDocument(uri);
+      const editor = await vscode.window.showTextDocument(doc, {
+        preview: false,
+      });
+      // Select the full span of the finding's lines and center it.
+      const start = new vscode.Position(range.start.line, 0);
+      const endLine = doc.lineAt(range.end.line);
+      const selection = new vscode.Selection(start, endLine.range.end);
+      editor.selection = selection;
+      editor.revealRange(selection, vscode.TextEditorRevealType.InCenter);
+
+      // Flash a whole-line highlight, then clear it after a moment.
+      const lineRange = new vscode.Range(
+        range.start.line,
+        0,
+        range.end.line,
+        endLine.range.end.character,
+      );
+      editor.setDecorations(findingHighlight, [lineRange]);
+      setTimeout(() => {
+        // Only clear if the same editor is still showing this document.
+        if (
+          vscode.window.activeTextEditor === editor &&
+          editor.document.uri.toString() === uri.toString()
+        ) {
+          editor.setDecorations(findingHighlight, []);
+        }
+      }, 2500);
+    },
+  );
+}
+
+export class SemgrepFindingsViewProvider implements vscode.TreeDataProvider<FindingNode> {
+  public static readonly viewType = "semgrep.view.findings";
+
+  private _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor() {
+    // Refresh whenever diagnostics change (scan finishes, file edited/closed).
+    vscode.languages.onDidChangeDiagnostics(() =>
+      this._onDidChangeTreeData.fire(),
+    );
+  }
+
+  // All URIs that currently have at least one Semgrep finding, sorted by path.
+  private semgrepFilesSorted(): { uri: vscode.Uri; count: number }[] {
+    return vscode.languages
+      .getDiagnostics()
+      .map(([uri, diags]) => ({
+        uri,
+        count: diags.filter((d) => d.source === SEMGREP_SOURCE).length,
+      }))
+      .filter((f) => f.count > 0)
+      .sort((a, b) => a.uri.fsPath.localeCompare(b.uri.fsPath));
+  }
+
+  private semgrepDiagnosticsFor(uri: vscode.Uri): vscode.Diagnostic[] {
+    return vscode.languages
+      .getDiagnostics(uri)
+      .filter((d) => d.source === SEMGREP_SOURCE)
+      .sort((a, b) => a.range.start.line - b.range.start.line);
+  }
+
+  getChildren(element?: FindingNode): vscode.ProviderResult<FindingNode[]> {
+    // Root: one node per file with findings.
+    if (!element) {
+      return this.semgrepFilesSorted().map((f) => ({
+        kind: "file",
+        uri: f.uri,
+        count: f.count,
+      }));
+    }
+    // A file node expands to its findings.
+    if (element.kind === "file") {
+      return this.semgrepDiagnosticsFor(element.uri).map((diagnostic) => ({
+        kind: "finding",
+        uri: element.uri,
+        diagnostic,
+      }));
+    }
+    // Findings are leaves.
+    return [];
+  }
+
+  getTreeItem(element: FindingNode): vscode.TreeItem {
+    if (element.kind === "file") {
+      const item = new vscode.TreeItem(
+        vscode.Uri.file(element.uri.fsPath),
+        vscode.TreeItemCollapsibleState.Expanded,
+      );
+      item.label = vscode.workspace.asRelativePath(element.uri);
+      item.description = `${element.count}`;
+      item.iconPath = vscode.ThemeIcon.File;
+      item.resourceUri = element.uri;
+      return item;
+    }
+
+    // Finding leaf: label is the human message; the full rule id lives in the
+    // tooltip (rule ids can be long, dotted, and prefixed by the config source).
+    const d = element.diagnostic;
+    const item = new vscode.TreeItem(
+      d.message,
+      vscode.TreeItemCollapsibleState.None,
+    );
+    const ruleId = codeToString(d.code);
+    item.description = `:${d.range.start.line + 1}`; // 1-based for humans
+    item.tooltip = new vscode.MarkdownString(`**${ruleId}**\n\n${d.message}`);
+    // Click opens the file and selects/centers the finding's line so it is easy
+    // to see (plain vscode.open with a narrow selection was hard to spot).
+    item.command = {
+      command: OPEN_FINDING_COMMAND,
+      title: "Open finding",
+      arguments: [element.uri, d.range],
+    };
+    return item;
+  }
+}
+
+// A diagnostic `code` may be a string, number, or { value, target }.
+export function codeToString(code: vscode.Diagnostic["code"]): string {
+  if (code == null) return "";
+  if (typeof code === "object") return String(code.value);
+  return String(code);
+}
+
+// Exported for unit testing: group a flat diagnostics list (as returned by
+// vscode.languages.getDiagnostics()) into the file -> finding tree shape.
+export function groupByFile(
+  all: [vscode.Uri, readonly vscode.Diagnostic[]][],
+): { uri: vscode.Uri; findings: vscode.Diagnostic[] }[] {
+  return all
+    .map(([uri, diags]) => ({
+      uri,
+      findings: diags
+        .filter((d) => d.source === SEMGREP_SOURCE)
+        .sort((a, b) => a.range.start.line - b.range.start.line),
+    }))
+    .filter((f) => f.findings.length > 0)
+    .sort((a, b) => a.uri.fsPath.localeCompare(b.uri.fsPath));
+}

--- a/src/views/findings.ts
+++ b/src/views/findings.ts
@@ -37,29 +37,29 @@ export function registerOpenFindingCommand(): vscode.Disposable {
       const editor = await vscode.window.showTextDocument(doc, {
         preview: false,
       });
+      // Clamp the range to the opened document. The diagnostic range was
+      // captured when the tree item was built; if the file shrank before the
+      // LS republished, range.{start,end}.line can be past doc.lineCount and
+      // doc.lineAt() would throw, breaking navigation.
+      const lastLine = Math.max(doc.lineCount - 1, 0);
+      const startLine = Math.min(range.start.line, lastLine);
+      const endLineNo = Math.min(range.end.line, lastLine);
+      const endLine = doc.lineAt(endLineNo);
+
       // Select the full span of the finding's lines and center it.
-      const start = new vscode.Position(range.start.line, 0);
-      const endLine = doc.lineAt(range.end.line);
-      const selection = new vscode.Selection(start, endLine.range.end);
+      const selection = new vscode.Selection(
+        new vscode.Position(startLine, 0),
+        endLine.range.end,
+      );
       editor.selection = selection;
       editor.revealRange(selection, vscode.TextEditorRevealType.InCenter);
 
-      // Flash a whole-line highlight, then clear it after a moment.
-      const lineRange = new vscode.Range(
-        range.start.line,
-        0,
-        range.end.line,
-        endLine.range.end.character,
-      );
-      editor.setDecorations(findingHighlight, [lineRange]);
+      // Flash a whole-line highlight, then clear it after a moment. Clear on the
+      // captured editor unconditionally — guarding on the active editor would
+      // leave the highlight stuck if the user switched tabs during the timeout.
+      editor.setDecorations(findingHighlight, [selection]);
       setTimeout(() => {
-        // Only clear if the same editor is still showing this document.
-        if (
-          vscode.window.activeTextEditor === editor &&
-          editor.document.uri.toString() === uri.toString()
-        ) {
-          editor.setDecorations(findingHighlight, []);
-        }
+        editor.setDecorations(findingHighlight, []);
       }, 2500);
     },
   );


### PR DESCRIPTION
## What

Adds a **Findings** view (first in the Semgrep sidebar) showing Semgrep results as a **file → finding** tree — a first-class home for findings in the IDE, not just the Problems tab.

- Click a finding → opens the file, **selects + centers + briefly highlights** the finding's line.
- Leaf label = the message; **full rule id in the tooltip**.
- Fed by `vscode.languages.getDiagnostics()` filtered to `source === "Semgrep"`, refreshed on `onDidChangeDiagnostics` — always in sync with the Problems tab by construction.

## Scope (first slice, deliberately minimal)

File → finding + navigation. **Out of scope here:** severity icons, count badges, product grouping (Code/Supply Chain/Secrets), 4-level severity. Those are deferred because **the LSP diagnostic carries none of that metadata today** — verified on both the OSS and bundled Pro engines (see `src/test/fixtures/hermetic/README.md`). Per-product sections and Critical/High/Medium/Low need a language-server change to expose the data; tracking that separately.

## Tests

`src/test/suite/findings.test.ts` — pure unit tests for the grouping logic (`groupByFile` / `codeToString`), no scan or language server required.

## Verification

Manually verified in the Extension Development Host against **OWASP Juice Shop**: the tree populates per file, clicking navigates to the highlighted line, tooltips show rule ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)