### PR TITLE
fix: valid problemMatcher for esbuild watch task (unblocks F5)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,16 @@
       "label": "npm: watch:esbuild",
       "script": "watch:esbuild",
       "isBackground": true,
-      "problemMatcher": "$esbuild-watch",
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "\\[watch\\] build started",
+          "endsPattern": "\\[watch\\] build finished"
+        }
+      },
       "presentation": {
         "reveal": "never"
       },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,9 +18,20 @@
       "script": "watch:esbuild",
       "isBackground": true,
       "problemMatcher": {
-        "pattern": {
-          "regexp": "^$"
-        },
+        "owner": "esbuild",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": [
+          {
+            "regexp": "^✘ \\[ERROR\\] (.+)$",
+            "message": 1
+          },
+          {
+            "regexp": "^\\s+(.+):(\\d+):(\\d+):$",
+            "file": 1,
+            "line": 2,
+            "column": 3
+          }
+        ],
         "background": {
           "activeOnStart": true,
           "beginsPattern": "\\[watch\\] build started",


### PR DESCRIPTION
`.vscode/tasks.json` referenced `$esbuild-watch` — a problem matcher provided only by the *esbuild Problem Matchers* extension. Without that extension installed, the watch task fails with `Invalid problemMatcher reference: $esbuild-watch`, and the **Launch Client** F5 config fails its `preLaunchTask`, so the Extension Development Host never launches.

Replaced with an inline background `problemMatcher` keyed on the markers `build.mjs` already emits (`[watch] build started` / `[watch] build finished`), so **F5 works out of the box** with no extra extension needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)